### PR TITLE
Allow true async requests in Synegy and Synergy::LPC

### DIFF
--- a/lib/Synergy/Hub.pm
+++ b/lib/Synergy/Hub.pm
@@ -393,6 +393,7 @@ sub http_put {
 sub http_request ($self, $method, $url, %args) {
   my $content = delete $args{Content};
   my $content_type = delete $args{Content_Type};
+  my $async = delete $args{async};
 
   my @args = $url;
 
@@ -416,12 +417,15 @@ sub http_request ($self, $method, $url, %args) {
   # The returned future will run the loop for us until we return. This makes
   # it asynchronous as far as the rest of the code is concerned, but
   # sychronous as far as the caller is concerned.
-  return $self->http->$method(
+
+  my $future = $self->http->$method(
     @args
   )->on_fail( sub {
     my $failure = shift;
     $Logger->log("Failed to $method $url: $failure");
-  } )->get;
+  } );
+
+  return $async ? $future : $future->get;
 }
 
 has time_zone_names => (


### PR DESCRIPTION
We do this using futures. This means Synergy::LPC isn't tied
to IO::Async (or any event framework).

Right now async is just used in damage report to speed up
its operations since it makes a number of calls (and one of
them is very slow).