### PR TITLE
LP: only nag for overlong timers three times

### DIFF
--- a/lib/Synergy/Timer.pm
+++ b/lib/Synergy/Timer.pm
@@ -106,6 +106,17 @@ has last_saw_timer => (
   is => 'rw',
 );
 
+has overlong_nag_count => (
+  is      => 'rw',
+  isa     => 'Int',
+  default => 0,
+  traits  => [ 'Counter' ],
+  handles => {
+    record_overlong_nag => 'inc',
+    reset_overlong_nag  => 'reset',
+  },
+);
+
 sub last_relevant_nag {
   my ($self) = @_;
 


### PR DESCRIPTION
Matthew reports that he was awoken in the middle of the night to 15
texts from Synergy about a timer he left running. That's not great...so
only do so three times, then give up.