### PR TITLE
Inabox preference updates

### DIFF
--- a/t/inabox.t
+++ b/t/inabox.t
@@ -26,6 +26,8 @@ my $result = Synergy::Tester->testergize({
       box_domain             => 'fm.local',
       vpn_config_file        => '',
       digitalocean_api_token => '1234',
+      inabox_default_version => 'bullseye',
+      inabox_datacentres     => ['nyc3', 'sfo3'],
     },
   },
   default_from => 'alice',


### PR DESCRIPTION
This updates the `inabox.version` and `inabox.datacentre` preferences.  They're now derived from config, with only a default 'buster' hard coded if the property isn't set.  