### PR TITLE
PagerDuty reactor

### DIFF
--- a/lib/Synergy/Reactor/PagerDuty.pm
+++ b/lib/Synergy/Reactor/PagerDuty.pm
@@ -1,0 +1,103 @@
+use v5.24.0;
+use warnings;
+use utf8;
+package Synergy::Reactor::PagerDuty;
+
+use Moose;
+use DateTime;
+with 'Synergy::Role::Reactor::EasyListening',
+     'Synergy::Role::HasPreferences';
+
+use experimental qw(signatures);
+use namespace::clean;
+
+use Data::Dumper::Concise;
+use JSON::MaybeXS qw(decode_json encode_json);
+use Synergy::Logger '$Logger';
+
+has api_endpoint_uri => (
+  is => 'ro',
+  isa => 'Str',
+  default => 'https://api.pagerduty.com',
+);
+
+has api_key => (
+  is => 'ro',
+  isa => 'Str',
+  required => 1,
+);
+
+sub listener_specs {
+  return (
+    {
+      name      => 'oncall',
+      method    => 'handle_oncall',
+      predicate => sub ($self, $e) { $e->was_targeted && $e->text =~ /^pd oncall\s*$/i },
+      help_entries => [
+        { title => 'oncall', text => '*oncall*: show a list of who is on call in PagerDuty right now' },
+      ],
+    },
+  );
+}
+
+sub _url_for ($self, $endpoint) {
+  return $self->api_endpoint_uri . $endpoint;
+}
+
+sub _pd_request ($self, $method, $endpoint, $data = undef) {
+  my %content;
+
+  if ($data) {
+    %content = (
+      Content_Type => 'application/json',
+      Content      => encode_json($data),
+    );
+  }
+
+  return $self->hub->http_request(
+    $method,
+    $self->_url_for($endpoint),
+    'Authorization' => "Token token=" . $self->api_key,
+    Accept         => 'application/vnd.pagerduty+json;version=2"',
+    %content,
+  )->then(sub ($res) {
+    unless ($res->is_success) {
+      my $code = $res->code;
+      $Logger->log([ "error talking to PagerDuty: %s", $res->as_string ]);
+      return Future->fail('http', { http_res => $res });
+    }
+
+    my $data = decode_json($res->content);
+    return Future->done($data);
+  });
+}
+
+sub handle_oncall ($self, $event) {
+  $event->mark_handled;
+
+  $self->_pd_request(GET => '/oncalls')
+    ->then(sub ($data) {
+      my @oncall = map {; $_->{user} }
+                   grep {; $_->{escalation_level} == 1}
+                   $data->{oncalls}->@*;
+
+      unless (@oncall) {
+        $event->reply("Nobody seems to be oncall right now...weird!");
+        return;
+      }
+
+      my @names = map {; $_->{summary} } @oncall;
+
+      $event->reply("current oncall: " . join q{, }, @names);
+    })
+    ->else(sub (@err) {
+      $event->reply("Something went wrong talking to PagerDuty, sorry.");
+      return;
+    })
+    ->retain;
+
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/Synergy/Reactor/PagerDuty.pm
+++ b/lib/Synergy/Reactor/PagerDuty.pm
@@ -12,7 +12,9 @@ use experimental qw(signatures);
 use namespace::clean;
 
 use Data::Dumper::Concise;
+use IO::Async::Timer::Periodic;
 use JSON::MaybeXS qw(decode_json encode_json);
+use List::Util qw(first);
 use Synergy::Logger '$Logger';
 
 has api_endpoint_uri => (
@@ -27,17 +29,112 @@ has api_key => (
   required => 1,
 );
 
+# the id for "Platform" or whatever. If we wind up having more than one
+# "service", we'll need to tweak this
+has service_id => (
+  is => 'ro',
+  isa => 'Str',
+  # required => 1,
+);
+
+has _pd_to_slack_map => (
+  is => 'ro',
+  isa => 'HashRef',
+  traits => ['Hash'],
+  lazy => 1,
+  clearer => '_clear_pd_to_slack_map',
+  handles => {
+    username_from_pd => 'get',
+  },
+  default => sub ($self) {
+    my %map;
+
+    for my $sy_username (keys $self->user_preferences->%*) {
+      my $pd_id = $self->get_user_preference($sy_username, 'user-id');
+      $map{$pd_id} = $sy_username;
+    }
+
+    return \%map;
+  },
+);
+
+has _slack_to_pd_map => (
+  is => 'ro',
+  isa => 'HashRef',
+  traits => ['Hash'],
+  lazy => 1,
+  clearer => '_clear_slack_to_pd_map',
+  handles => {
+    pd_from_username => 'get',
+  },
+  default => sub ($self) {
+    my %map = reverse $self->_pd_to_slack_map->%*;
+    return \%map;
+  },
+);
+
+has oncall_channel_name => (
+  is => 'ro',
+  isa => 'Str',
+);
+
+has oncall_channel => (
+  is => 'ro',
+  lazy => 1,
+  default => sub ($self) {
+    return unless my $channel_name = $self->oncall_channel_name;
+    return $self->hub->channel_named($channel_name);
+  }
+);
+
+has oncall_group_address => (
+  is => 'ro',
+  isa => 'Str',
+);
+
+has oncall_list => (
+  is => 'ro',
+  isa => 'ArrayRef',
+  writer => '_set_oncall_list',
+  lazy => 1,
+  default => sub { [] },
+);
+
+around '_set_oncall_list' => sub ($orig, $self, @rest) {
+  $self->$orig(@rest);
+  $self->save_state;
+};
+
+sub start ($self) {
+  if ($self->oncall_channel && $self->oncall_group_address) {
+    my $check_oncall_timer = IO::Async::Timer::Periodic->new(
+      first_interval => 30,   # don't start immediately
+      interval       => 150,
+      on_tick        => sub { $self->_check_at_oncall },
+    );
+
+    $check_oncall_timer->start;
+    $self->hub->loop->add($check_oncall_timer);
+  }
+}
+
 sub listener_specs {
   return (
     {
       name      => 'oncall',
       method    => 'handle_oncall',
-      predicate => sub ($self, $e) { $e->was_targeted && $e->text =~ /^pd oncall\s*$/i },
+      predicate => sub ($self, $e) { $e->was_targeted && $e->text =~ /^oncall\s*$/i },
       help_entries => [
         { title => 'oncall', text => '*oncall*: show a list of who is on call in PagerDuty right now' },
       ],
     },
   );
+}
+
+sub state ($self) {
+  return {
+    oncall_list => $self->oncall_list,
+  };
 }
 
 sub _url_for ($self, $endpoint) {
@@ -57,8 +154,8 @@ sub _pd_request ($self, $method, $endpoint, $data = undef) {
   return $self->hub->http_request(
     $method,
     $self->_url_for($endpoint),
-    'Authorization' => "Token token=" . $self->api_key,
-    Accept         => 'application/vnd.pagerduty+json;version=2"',
+    Authorization => 'Token token=' . $self->api_key,
+    Accept        => 'application/vnd.pagerduty+json;version=2',
     %content,
   )->then(sub ($res) {
     unless ($res->is_success) {
@@ -72,31 +169,111 @@ sub _pd_request ($self, $method, $endpoint, $data = undef) {
   });
 }
 
-sub handle_oncall ($self, $event) {
-  $event->mark_handled;
+after register_with_hub => sub ($self, @) {
+  my $state = $self->fetch_state // {};   # load prefs
+  if (my $list = $state->{oncall_list}) {
+    $self->_set_oncall_list($list);
+  }
+};
 
+sub _current_oncall_ids ($self) {
   $self->_pd_request(GET => '/oncalls')
     ->then(sub ($data) {
       my @oncall = map {; $_->{user} }
                    grep {; $_->{escalation_level} == 1}
                    $data->{oncalls}->@*;
 
-      unless (@oncall) {
-        $event->reply("Nobody seems to be oncall right now...weird!");
-        return;
+      # XXX probably not generic enough
+      my @ids = map {; $_->{id} } @oncall;
+      return Future->done(@ids);
+    });
+}
+
+# This returns a Future that, when done, gives a boolean as to whether or not
+# $who is oncall right now.
+sub _user_is_oncall ($self, $who) {
+  return $self->_current_oncall_ids
+    ->then(sub (@ids) {
+      my $want_id = $self->get_user_preference($who->username, 'user-id');
+      return Future->done(!! first { $_ eq $want_id } @ids)
+    });
+}
+
+sub handle_oncall ($self, $event) {
+  $event->mark_handled;
+
+  $self->_current_oncall_ids
+    ->then(sub (@ids) {
+        my @users = map {; $self->username_from_pd($_) // $_ } @ids;
+        return $event->reply('current oncall: ' . join(', ', sort @users));
+    })
+    ->else(sub { $event->reply("I couldn't look up who's on call. Sorry!") })
+    ->retain;
+}
+
+sub _check_at_oncall ($self) {
+  my $channel = $self->oncall_channel;
+  return unless $channel && $channel->isa('Synergy::Channel::Slack');
+
+  $Logger->log("checking PagerDuty for oncall updates");
+
+  return $self->_current_oncall_ids
+    ->then(sub (@ids) {
+      my @new = sort @ids;
+      my @have = sort $self->oncall_list->@*;
+
+      if (join(',', @have) eq join(',', @new)) {
+        $Logger->log("no changes in oncall list detected");
+        return Future->done;
       }
 
-      my @names = map {; $_->{summary} } @oncall;
+      $Logger->log([ "will update oncall list; is now %s", join(', ', @new) ]);
 
-      $event->reply("current oncall: " . join q{, }, @names);
-    })
-    ->else(sub (@err) {
-      $event->reply("Something went wrong talking to PagerDuty, sorry.");
-      return;
-    })
-    ->retain;
+      my @userids = map  {; $_->identity_for($channel->name) }
+                    map  {; $self->hub->user_directory->user_named($_) }
+                    grep {; defined }
+                    map  {; $self->username_from_pd($_) }
+                    @new;
 
+      my $f = $channel->slack->api_call(
+        'usergroups.users.update',
+        {
+          usergroup => $self->oncall_group_address,
+          users => join(q{,}, @userids),
+        },
+        privileged => 1,
+      );
+
+      $f->on_done(sub ($http_res) {
+        my $data = decode_json($http_res->decoded_content);
+        unless ($data->{ok}) {
+          $Logger->log(["error updating oncall slack group: %s", $data]);
+          return;
+        }
+
+        # Don't set our local cache until we're sure we've actually updated
+        # the slack group; this way, if something goes wrong setting the group
+        # the first time, we'll actually try again the next time around,
+        # rather than just saying "oh, nothing changed, great!"
+        $self->_set_oncall_list(\@new);
+      });
+
+      return $f;
+    })->retain;
 }
+
+__PACKAGE__->add_preference(
+  name      => 'user-id',
+  after_set => sub ($self, $username, $val) {
+    $self->_clear_pd_to_slack_map,
+    $self->_clear_slack_to_pd_map,
+  },
+  validator => sub ($self, $value, @) {
+    return (undef, 'user id cannot contain spaces') if $value =~ /\s/;
+
+    return $value;
+  },
+);
 
 __PACKAGE__->meta->make_immutable;
 


### PR DESCRIPTION
NOTE: this is almost certainly incompatible with the VO reactor. It's possible they might both work at the same time, but I haven't tested it.

This is more or less a direct port of the VictorOps reactor, with the necessary changes for the differences between the two services. It's likely we'll want to improve this somewhat, but this gets us to feature parity. The commit messages have more detail, where necessary.

The most notable thing I _didn't_ port was extra behavior on demaint: that is `demaint /resolve` is no longer a thing, nor is `demaint /noresolve`, which never quite worked right anyway. 