### PR TITLE
Move prom object out of reactor and into hub

### DIFF
--- a/lib/Synergy/Environment.pm
+++ b/lib/Synergy/Environment.pm
@@ -40,6 +40,11 @@ has server_port => (
   default => 8118,
 );
 
+has metrics_path => (
+  is => 'ro',
+  isa => 'Str',
+);
+
 has tls_cert_file => (
   is => 'ro',
   isa => 'Str',

--- a/lib/Synergy/Hub.pm
+++ b/lib/Synergy/Hub.pm
@@ -58,6 +58,12 @@ has server => (
   },
 );
 
+has prom => (
+  is => 'ro',
+  lazy => 1,
+  default => sub { Prometheus::Tiny->new },
+);
+
 for my $pair (
   [ qw( channel channels ) ],
   [ qw( reactor reactors ) ],
@@ -208,6 +214,10 @@ sub set_loop ($self, $loop) {
 
   $_->start for $self->reactors;
   $_->start for $self->channels;
+
+  if (my $metrics_path = $self->env->metrics_path) {
+    $self->server->register_path($metrics_path, $self->prom->psgi, 'the hub');
+  }
 
   return $loop;
 }

--- a/lib/Synergy/Reactor/Prometheus.pm
+++ b/lib/Synergy/Reactor/Prometheus.pm
@@ -4,21 +4,11 @@ package Synergy::Reactor::Prometheus;
 
 use Moose;
 with 'Synergy::Role::Reactor::EasyListening';
-with 'Synergy::Role::HTTPEndpoint';
 
 use experimental qw(signatures);
 use namespace::clean;
 
 use Prometheus::Tiny 0.002;
-
-has '+http_path' => (
-  default => '/metrics',
-);
-
-has _prom_client => (
-  is => 'ro',
-  default => sub { Prometheus::Tiny->new },
-);
 
 sub listener_specs {
   return {
@@ -29,17 +19,10 @@ sub listener_specs {
 }
 
 sub start ($self) {
-  my $prom = $self->_prom_client;
-
-  $prom->declare('synergy_events_received_total',
+  $self->prom->declare('synergy_events_received_total',
     help => 'Number of events received by reactors',
     type => 'counter',
   );
-}
-
-sub http_app ($self, $env) {
-  state $app = $self->_prom_client->psgi;
-  $app->($env);
 }
 
 sub count_event ($self, $event) {
@@ -47,7 +30,7 @@ sub count_event ($self, $event) {
            ? $event->from_user->username
            : $event->from_address;
 
-  $self->_prom_client->inc(synergy_events_received_total => {
+  $self->prom->inc(synergy_events_received_total => {
     channel   => $event->from_channel->name,
     user      => $from,
     in        => $event->from_channel->describe_conversation($event),

--- a/lib/Synergy/Role/HubComponent.pm
+++ b/lib/Synergy/Role/HubComponent.pm
@@ -25,7 +25,7 @@ has hub => (
   predicate => '_has_hub',
   init_arg  => undef,
   weak_ref  => 1,
-  handles   => [ qw( loop ) ],
+  handles   => [ qw( loop prom ) ],
 );
 
 sub hub ($self) {

--- a/t/prometheus.t
+++ b/t/prometheus.t
@@ -21,6 +21,7 @@ my $synergy = Synergy::Hub->synergize(
   {
     user_directory => "t/data/users.yaml",
     server_port => empty_port(),
+    metrics_path => '/metrics',
     channels => {
       'test-channel' => {
         class     => 'Synergy::Channel::Test',


### PR DESCRIPTION
I want to be able to use this from more places, and making it
first-class seems reasonable.