### PR TITLE
inabox: move default datacentre for AU sfo2 --> sfo3

### DIFF
--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -590,7 +590,7 @@ sub _region_for_user ($self, $user) {
   my $tz = $user->time_zone;
   my ($area) = split '/', $tz;
   return
-    $area eq 'Australia' ? 'sfo2' :
+    $area eq 'Australia' ? 'sfo3' :
     $area eq 'Europe'    ? 'ams3' :
                            'nyc3';
 }


### PR DESCRIPTION
There are some droplet types available in sfo3 that Butch wants for the
automated testing work.  It doesn't make sense to have snapshots at both
sfo2 and sfo3 long term so update the default so we can remove the snapshots from sfo2.

There will be some users with a preference set for sfo2.  Would it be best to "send an email" to get everyone with it manually set to update it, or just update it from underneath them (and if so, how?)

