### PR TITLE
CommandPost: a new framework for coding reactions

### DIFF
--- a/lib/Synergy/CommandPost.pm
+++ b/lib/Synergy/CommandPost.pm
@@ -58,6 +58,13 @@ package Synergy::CommandPost::Object {
       Sub::Install::install_sub({
         as    => "add_$thing",
         code  => sub ($self, $name, $arg, $method) {
+          # Look, there's not reason you can't actually have two listeners,
+          # named Zorch and zorch.  But there's no reason you really ought to
+          # do that either.  So don't.  I'll be proscribing any
+          # case-insensitive conflict for the same of commands, where it _does_
+          # matter. -- rjbs, 2022-01-14
+          $name = lc $name;
+
           Carp::confess("already have a $thing named $name")
             if $self->$check($name);
 
@@ -95,6 +102,7 @@ package Synergy::CommandPost::Object {
     ### First, is there a command to match the first word of the message?
     if ($targeted) {
       my ($first, $rest) = split /\s+/, $event->text, 2;
+      $first = lc $first;
 
       if (my $command = $self->_command_named($first)) {
         my $method = $command->{method};

--- a/lib/Synergy/CommandPost.pm
+++ b/lib/Synergy/CommandPost.pm
@@ -1,0 +1,191 @@
+use v5.24.0;
+use warnings;
+package Synergy::CommandPost;
+
+use experimental 'signatures';
+
+use Synergy::PotentialReaction;
+
+use Sub::Exporter -setup => {
+  groups => { default => \'_generate_command_system' },
+};
+
+package Synergy::CommandPost::Object {
+  use Moose;
+
+  use experimental 'signatures';
+
+  has is_final => (is => 'rw');
+
+  has commands => (
+    isa => 'HashRef',
+    init_arg  => undef,
+    default   => sub {  {}  },
+    traits    => [ 'Hash' ],
+    handles   => {
+      _command_named    => 'get',
+      _register_command => 'set',
+    },
+  );
+
+  has listeners => (
+    isa => 'HashRef',
+    init_arg  => undef,
+    default   => sub {  {}  },
+    traits    => [ 'Hash' ],
+    handles   => {
+      _listener_kv    => 'kv',
+      _listener_named => 'get',
+      _register_listener  => 'set',
+    },
+  );
+
+  has reactions => (
+    isa => 'HashRef',
+    init_arg  => undef,
+    default   => sub {  {}  },
+    traits    => [ 'Hash' ],
+    handles   => {
+      _reaction_kv    => 'kv',
+      _reaction_named => 'get',
+      _register_reaction  => 'set',
+    },
+  );
+
+  BEGIN {
+    for my $thing (qw(command listener reaction)) {
+      my $check = "_$thing\_named";
+      my $add   = "_register_$thing";
+
+      Sub::Install::install_sub({
+        as    => "add_$thing",
+        code  => sub ($self, $name, $arg, $method) {
+          Carp::confess("already have a $thing named $name")
+            if $self->$check($name);
+
+          my $to_store = { method => $method, %$arg };
+
+          $self->$add($name, $to_store);
+
+          return;
+        }
+      });
+    }
+  }
+
+  has help => (
+    isa => 'ArrayRef',
+    init_arg  => undef,
+    default   => sub {  []  },
+    traits    => [ 'Array' ],
+    handles   => {
+      _add_help => 'push',
+      _help_entries => 'elements',
+    },
+  );
+
+  sub add_help ($self, $name, $arg, $text) {
+    my $to_store = { %$arg, title => $name, text => $text };
+    $self->_add_help($to_store);
+    return;
+  }
+
+  sub potential_reactions_to ($self, $reactor, $event) {
+    my @reactions;
+    my $targeted = $event->was_targeted;
+
+    ### First, is there a command to match the first word of the message?
+    my ($first, $rest) = split /\s+/, $event->text, 2;
+
+    if ($targeted) {
+      if (my $command = $self->_command_named($first)) {
+        my $method = $command->{method};
+
+        push @reactions, Synergy::PotentialReaction->new({
+          reactor => $reactor,
+          name    => "command-$first",
+          is_exclusive  => 1,
+          event_handler => sub {
+            $event->mark_handled;
+            $reactor->$method($event, $rest)
+          },
+        });
+      }
+    }
+
+    ### Next, allow all the listeners to have a crack at the event.
+    for my $listener_pair ($self->_listener_kv) {
+      my $method = $listener_pair->[1]{method};
+
+      push @reactions, Synergy::PotentialReaction->new({
+        reactor => $reactor,
+        name    => "listener-$listener_pair->[0]",
+        is_exclusive  => 0,
+        event_handler => sub { $reactor->$method($event) },
+      });
+    }
+
+    ### Finally, reactions are the last-resort flexible option.
+    my @reaction_kv = $self->_reaction_kv;
+    @reaction_kv = grep {; $_->[1]{targeted} } @reaction_kv if ! $targeted;
+    for my $reaction_pair (@reaction_kv) {
+      my ($name, $reaction) = @$reaction_pair;
+      my $match = $reaction->{matcher}->($event);
+      next unless $match;
+
+      my $method = $reaction->{method};
+
+      push @reactions, Synergy::PotentialReaction->new({
+        reactor => $reactor,
+        name    => "reaction-$name",
+        is_exclusive  => $reaction->{exclusive},
+        event_handler => sub { $reactor->$method($event, @$match) },
+      });
+    }
+
+    return @reactions;
+  }
+
+  no Moose;
+}
+
+sub _generate_command_system ($class, $, $arg, @) {
+  my $object = Synergy::CommandPost::Object->new;
+  return {
+    potential_reactions_to => sub ($reactor, $event) {
+      $object->potential_reactions_to($reactor, $event);
+    },
+    help_entries => sub ($self) {
+      [ $object->_help_entries ];
+    },
+    command => sub ($name, $arg, $code) {
+      $object->add_command($name, $arg, $code);
+
+      if ($arg->{help}) {
+        $object->add_help($name, {}, $arg->{help});
+      }
+
+      return;
+    },
+    help => sub ($name, $text) {
+      $object->add_help($name, {}, $text);
+      return;
+    },
+    listener => sub ($name, $code) {
+      $object->add_listener($name, {}, $code);
+
+      return;
+    },
+    reaction => sub ($name, $arg, $code) {
+      $object->add_reaction($name, $arg, $code);
+
+      if ($arg->{help}) {
+        $object->add_help($name, {}, $arg->{help});
+      }
+
+      return;
+    },
+  };
+}
+
+1;

--- a/lib/Synergy/CommandPost.pm
+++ b/lib/Synergy/CommandPost.pm
@@ -97,10 +97,10 @@ package Synergy::CommandPost::Object {
 
   sub potential_reactions_to ($self, $reactor, $event) {
     my @reactions;
-    my $targeted = $event->was_targeted;
+    my $event_was_targeted = $event->was_targeted;
 
     ### First, is there a command to match the first word of the message?
-    if ($targeted) {
+    if ($event_was_targeted) {
       my ($first, $rest) = split /\s+/, $event->text, 2;
       $first = lc $first;
 
@@ -133,7 +133,11 @@ package Synergy::CommandPost::Object {
 
     ### Finally, reactions are the last-resort flexible option.
     my @reaction_kv = $self->_reaction_kv;
-    @reaction_kv = grep {; $_->[1]{targeted} } @reaction_kv if ! $targeted;
+
+    unless ($event_was_targeted) {
+      @reaction_kv = grep {; ! $_->[1]{targeted} } @reaction_kv;
+    }
+
     for my $reaction_pair (@reaction_kv) {
       my ($name, $reaction) = @$reaction_pair;
       my $match = $reaction->{matcher}->($event);

--- a/lib/Synergy/CommandPost.pm
+++ b/lib/Synergy/CommandPost.pm
@@ -172,7 +172,6 @@ sub _generate_command_system ($class, $, $arg, @) {
     },
     listener => sub ($name, $code) {
       $object->add_listener($name, {}, $code);
-
       return;
     },
     reaction => sub ($name, $arg, $code) {

--- a/lib/Synergy/CommandPost.pm
+++ b/lib/Synergy/CommandPost.pm
@@ -93,9 +93,9 @@ package Synergy::CommandPost::Object {
     my $targeted = $event->was_targeted;
 
     ### First, is there a command to match the first word of the message?
-    my ($first, $rest) = split /\s+/, $event->text, 2;
-
     if ($targeted) {
+      my ($first, $rest) = split /\s+/, $event->text, 2;
+
       if (my $command = $self->_command_named($first)) {
         my $method = $command->{method};
 
@@ -149,6 +149,7 @@ package Synergy::CommandPost::Object {
 
 sub _generate_command_system ($class, $, $arg, @) {
   my $object = Synergy::CommandPost::Object->new;
+
   return {
     potential_reactions_to => sub ($reactor, $event) {
       $object->potential_reactions_to($reactor, $event);

--- a/lib/Synergy/CommandPost.pm
+++ b/lib/Synergy/CommandPost.pm
@@ -15,8 +15,6 @@ package Synergy::CommandPost::Object {
 
   use experimental 'signatures';
 
-  has is_final => (is => 'rw');
-
   has commands => (
     isa => 'HashRef',
     init_arg  => undef,

--- a/lib/Synergy/Reactor/Help.pm
+++ b/lib/Synergy/Reactor/Help.pm
@@ -30,7 +30,14 @@ sub handle_help ($self, $event) {
 
   my ($help, $rest) = split /\s+/, $event->text, 2;
 
-  my @help = map {; $_->help_entries->@* } $self->hub->reactors;
+  # Another option here would be to add "requires 'help_entries'" to the
+  # Reactor role, but this gets to be a bit of a pain with CommandPost, because
+  # it's not a role and so its imported function isn't respected as a method.
+  # This could (and probably should) be fixed by making CommandPost a role, but
+  # it's a little complicated, so I'm just doing this, because this is easy to
+  # do and easy to understand. -- rjbs, 2022-01-02
+  my @help = map {; $_->can('help_entries') && $_->help_entries->@* }
+             $self->hub->reactors;
 
   unless ($rest) {
     my $help_str = join q{, }, uniq sort map  {; $_->{title} }

--- a/lib/Synergy/Role/Reactor.pm
+++ b/lib/Synergy/Role/Reactor.pm
@@ -9,12 +9,6 @@ use namespace::clean;
 
 with 'Synergy::Role::HubComponent';
 
-sub help_entries {
-  # Generally here to be overridden.  Should return an arrayref of help
-  # entries, each with { title => ..., text => ... }
-  return [];
-}
-
 sub start ($self) { }
 
 sub resolve_name ($self, $name, $resolving_user) {

--- a/lib/Synergy/Role/Reactor/EasyListening.pm
+++ b/lib/Synergy/Role/Reactor/EasyListening.pm
@@ -21,13 +21,11 @@ has listeners => (
   },
 );
 
-around help_entries => sub ($orig, $self, @rest) {
-  my $entries = $self->$orig(@rest);
+sub help_entries ($self) {
   return [
-    @$entries,
     (map {; @{ $_->{help_entries} // [] } } $self->listeners),
   ];
-};
+}
 
 sub potential_reactions_to ($self, $event) {
   my @matches = $self->listeners;


### PR DESCRIPTION
CommandPost: a new framework for coding reactions

In previous versions of Synergy, all reaction was governed by Listener objects, which set the form for how reaction could occur.  This was replaced by the "potential_reactions_to" method, which more readily allowed reactors to choose their own means by which to react to events.

CommandPost is proof of concept of a new way to build reactors.  It puts more things in one place.  It simplifies the common cases of writing named commands and mention-listeners.  It helps avoid duplication, for example repeating a regex in the reaction body as well as the EasyListening-style predicate sub.

Instead of predicates, CommandPost provides "matchers", which return a value that can then be fed to the reaction method, allowing for single-pass parsing (for example).

In addition to providing an implementation of "potential_reactions_to", CommandPost provides four declarative helpers:

* command NAME => {ARG} => METHOD

This declares a command: a reaction that must be targeted and exclusive, and which responds when a message starts with the command name.

* listener NAME => METHOD

This declares a listener: a non-exclusive reaction that gets called on every event.

* reaction NAME => {ARG} => METHOD

This declares a flexible reaction that may be target and may be exclusive.  It's similar to the listener declarations in EasyListening.

* help TITLE => TEXT

This adds a help entry to the reactor, in case you want to add help topics that don't correspond to a command.
