### PR TITLE
replace timers to clear caches with just-in-time reaping

### DIFF
--- a/lib/Synergy/Reactor/Fortune.pm
+++ b/lib/Synergy/Reactor/Fortune.pm
@@ -41,36 +41,18 @@ has _fortunes => (
 has _scolding_counts => (
   is => 'ro',
   isa => 'HashRef',
-  traits => ['Hash'],
-  lazy => 1,
   default => sub { {} },
-  handles => {
-    remove_scolding    => 'delete',
-    recent_scoldings   => 'keys',
-    scolding_data_for  => 'get',
-    note_scolding_data => 'set',
-  },
 );
 
-# If it's been more than 5 minutes since the last time you asked for a fortune
-# in this channel, you can ask again.
-has scold_reaper => (
-  is => 'ro',
-  lazy => 1,
-  default => sub ($self) {
-    return IO::Async::Timer::Periodic->new(
-      interval => 30,
-      on_tick  => sub {
-        my $then = time - (60 * 5);
+sub _update_scolding_count_for ($self, $key) {
+  my $counts = $self->_scolding_counts;
 
-        for my $key ($self->recent_scoldings) {
-          my ($count, $ts) = $self->scolding_data_for($key)->@*;
-          $self->remove_scolding($key) if $ts lt $then;
-        }
-      },
-    );
-  }
-);
+  delete $counts->{$key} if $counts->{$key} && time - 300 > $counts->{$key}[1];
+
+  $counts->{$key} //= [ 0, time ];
+
+  return ++$counts->{$key}[0];
+}
 
 sub listener_specs {
   return (
@@ -97,10 +79,6 @@ END
   );
 }
 
-sub start ($self) {
-  $self->hub->loop->add($self->scold_reaper->start);
-}
-
 sub handle_fortune ($self, $event) {
   $event->mark_handled;
 
@@ -112,10 +90,7 @@ sub handle_fortune ($self, $event) {
   if ($event->is_public) {
     my $src = $event->source_identifier;
 
-    my $data = $self->scolding_data_for($src) // [];
-    my $count = $data->[0] // 0;
-
-    $self->note_scolding_data($src, [ $count + 1, time]);
+    my $count = $self->_update_scolding_count_for($src);
 
     if ($count >= 3) {
       $event->ephemeral_reply("No fishing for your favorite fortunes in public!");

--- a/lib/Synergy/Reactor/GitLab.pm
+++ b/lib/Synergy/Reactor/GitLab.pm
@@ -70,59 +70,41 @@ has relevant_owners => (
   default => sub { [] },
 );
 
-has _recent_mr_expansions => (
-  is => 'ro',
+# key => time
+has _expansion_cache_guts => (
+  is  => 'ro',
   isa => 'HashRef',
-  traits => ['Hash'],
-  lazy => 1,
-  default => sub { {} },
-  handles => {
-    has_expanded_mr_recently => 'exists',
-    note_mr_expansion        => 'set',
-    remove_mr_expansion      => 'delete',
-    recent_mr_expansions     => 'keys',
-    mr_expansion_for         => 'get',
-  },
+  traits  => [ 'Hash' ],
+  default => sub {  {}  },
 );
 
-has _recent_commit_expansions => (
-  is => 'ro',
-  isa => 'HashRef',
-  traits => ['Hash'],
-  lazy => 1,
-  default => sub { {} },
-  handles => {
-    has_expanded_commit_recently => 'exists',
-    note_commit_expansion        => 'set',
-    remove_commit_expansion      => 'delete',
-    recent_commit_expansions     => 'keys',
-    commit_expansion_for         => 'get',
-  },
-);
+sub _expansion_cache ($self) {
+  my $guts = $self->_expansion_cache_guts;
 
-# We'll only keep records of expansions for 5m or so.
-has expansion_record_reaper => (
-  is => 'ro',
-  lazy => 1,
-  default => sub ($self) {
-    return IO::Async::Timer::Periodic->new(
-      interval => 30,
-      on_tick  => sub {
-        my $then = time - (60 * 5);
-
-        for my $key ($self->recent_mr_expansions) {
-          my $ts = $self->mr_expansion_for($key);
-          $self->remove_mr_expansion($key) if $ts lt $then;
-        }
-
-        for my $key ($self->recent_commit_expansions) {
-          my $ts = $self->commit_expansion_for($key);
-          $self->remove_commit_expansion($key) if $ts lt $then;
-        }
-      },
-    );
+  for my $key (keys %$guts) {
+    delete $guts->{$key} if time - 300 > $guts->{$key};
   }
-);
+
+  return $guts;
+}
+
+sub has_expanded_mr_recently ($self, $key) {
+  return exists $self->_expansion_cache->{"MR_$key"};
+}
+
+sub note_mr_expansion ($self, $key) {
+  $self->_expansion_cache_guts->{"MR_$key"} = time;
+  return;
+}
+
+sub has_expanded_commit_recently ($self, $key) {
+  return exists $self->_expansion_cache->{"COMMIT_$key"};
+}
+
+sub note_commit_expansion ($self, $key) {
+  $self->_expansion_cache_guts->{"COMMIT_$key"} = time;
+  return;
+}
 
 after register_with_hub => sub ($self, @) {
   if (my $state = $self->fetch_state) {
@@ -145,7 +127,6 @@ sub start ($self) {
   );
 
   $self->hub->loop->add($timer->start);
-  $self->hub->loop->add($self->expansion_record_reaper->start);
 }
 
 sub state ($self) {
@@ -828,7 +809,7 @@ sub handle_merge_request ($self, $event) {
         return;
       }
 
-      $self->note_mr_expansion($key, time);
+      $self->note_mr_expansion($key);
 
       my $state = $data->{state};
 
@@ -974,7 +955,7 @@ sub handle_commit ($self, $event) {
         return;
       }
 
-      $self->note_commit_expansion($key, time);
+      $self->note_commit_expansion($key);
 
       my $commit_url = sprintf("%s/%s/commit/%s",
         $self->url_base,


### PR DESCRIPTION
My take: no reason to leave things sitting on the event loop all the time.  Instead, we'll let things wait to get cleaned until the next read.  In theory, some more memory might get left committed, but it's tiny hash entries in all cases.