### PR TITLE
LinearNotification: updates to slack notification message

### DIFF
--- a/lib/Synergy/Reactor/LinearNotification.pm
+++ b/lib/Synergy/Reactor/LinearNotification.pm
@@ -141,11 +141,14 @@ sub http_app ($self, $env) {
           return Future->done($by_id{$payload->{data}->{creatorId}}->{displayName} // 'unknown');
         })->then(sub ($who) {
           my $desc = $was_create ? 'New task created for' : 'Existing task moved to';
+          my $app = $was_create ? 'Zendesk' : 'Linear';
+          $who = 'someone' unless $was_create;
 
           my $text = sprintf
-            "$ESCALATION_EMOJI %s escalation by %s in zendesk: %s (%s)",
+            "$ESCALATION_EMOJI %s escalation by %s in %s: %s (%s)",
             $desc,
             $who,
+            $app
             $payload->{data}{title},
             $payload->{url};
 


### PR DESCRIPTION
A couple of small fixes:

    - The notification message specifies if the escalated issue was
      created from Zendesk or updated to escalation in Linear

    - The notification message was incorrectly identifying the person who
      moved a issue to escalation as the creator of the issue, rather than
      the person who added the support blocker label. Linear does not give
      us an easy way to determine who the actor was, so we're removing this
      bit of info for now.