### PR TITLE
CommandPost: refactored, testable, extended

### DIFF
--- a/lib/Synergy/CommandPost.pm
+++ b/lib/Synergy/CommandPost.pm
@@ -176,6 +176,12 @@ sub _generate_command_system ($class, $, $arg, @) {
         $object->add_help($name, {}, $arg->{help});
       }
 
+      if ($arg->{aliases}) {
+        for my $alias ($arg->{aliases}->@*) {
+          $object->add_command($alias, $arg, $code);
+        }
+      }
+
       return;
     },
     help => sub ($name, $text) {

--- a/lib/Synergy/CommandPost.pm
+++ b/lib/Synergy/CommandPost.pm
@@ -27,6 +27,14 @@ sub _generate_command_system ($class, $, $arg, $) {
       if ($arg->{aliases}) {
         for my $alias ($arg->{aliases}->@*) {
           $object->add_command($alias, $arg, $code);
+
+          if ($arg->{help}) {
+            $object->add_help(
+              $alias,
+              { unlisted => 1 },
+              qq{$alias is an alias for $name.  See "help $name".}
+            );
+          }
         }
       }
 

--- a/lib/Synergy/Reactor/CatPic.pm
+++ b/lib/Synergy/Reactor/CatPic.pm
@@ -6,7 +6,8 @@ use utf8;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor::CommandPost';
+with 'Synergy::Role::Reactor',
+     'Synergy::Role::Reactor::CommandPost';
 
 use Synergy::CommandPost;
 

--- a/lib/Synergy/Reactor/CatPic.pm
+++ b/lib/Synergy/Reactor/CatPic.pm
@@ -195,9 +195,9 @@ sub _build_reactions ($self, @) {
 reaction cat_pic => {
   exclusive => 1,
   targeted  => 1,
-  matcher   => sub ($event) {
+  matcher   => sub ($text, @) {
     # TODO: make this an error instead of a give-up?
-    return unless $event->text =~ /\Acat(?:\s+(pic|jpg|gif|png))?\z/i;
+    return unless $text =~ /\Acat(?:\s+(pic|jpg|gif|png))?\z/i;
     return [ $1 || 'jpg,gif,png' ];
   },
 }, sub ($self, $event, $fmt) {
@@ -293,8 +293,7 @@ listener jazz_pic => sub ($self, $event) {
 reaction dog_pic => {
   exclusive => 1,
   targeted  => 1,
-  matcher   => sub ($event) {
-    my $text = $event->text;
+  matcher   => sub ($text, @) {
     return unless $text =~ /\Adog\s+pic\z/i
                || $text =~ /\Aunleash\s+the\s+hounds\z/i;
     return [];

--- a/lib/Synergy/Reactor/CatPic.pm
+++ b/lib/Synergy/Reactor/CatPic.pm
@@ -192,7 +192,7 @@ sub _build_reactions ($self, @) {
   return $reactions;
 }
 
-reaction cat_pic => {
+responder cat_pic => {
   exclusive => 1,
   targeted  => 1,
   matcher   => sub ($text, @) {
@@ -290,7 +290,7 @@ listener jazz_pic => sub ($self, $event) {
 
 # TODO: we want a way to write some kind of custom prefix matching hybrid
 # listener / command?
-reaction dog_pic => {
+responder dog_pic => {
   exclusive => 1,
   targeted  => 1,
   matcher   => sub ($text, @) {

--- a/lib/Synergy/Reactor/CatPic.pm
+++ b/lib/Synergy/Reactor/CatPic.pm
@@ -6,7 +6,7 @@ use utf8;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::CommandPost';
 
 use Synergy::CommandPost;
 

--- a/lib/Synergy/Reactor/Clox.pm
+++ b/lib/Synergy/Reactor/Clox.pm
@@ -4,7 +4,7 @@ package Synergy::Reactor::Clox;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::CommandPost';
 
 use Synergy::CommandPost;
 

--- a/lib/Synergy/Reactor/Clox.pm
+++ b/lib/Synergy/Reactor/Clox.pm
@@ -4,7 +4,8 @@ package Synergy::Reactor::Clox;
 
 use Moose;
 use DateTime;
-with 'Synergy::Role::Reactor::CommandPost';
+with 'Synergy::Role::Reactor',
+     'Synergy::Role::Reactor::CommandPost';
 
 use Synergy::CommandPost;
 

--- a/lib/Synergy/Reactor/GoodMorning.pm
+++ b/lib/Synergy/Reactor/GoodMorning.pm
@@ -33,8 +33,9 @@ my @BYE = (
   "Farewell, %n.",
 );
 
-reaction good_morning => {
-  targeted => 1, matcher => sub {[]}
+responder good_morning => {
+  targeted => 1,
+  matcher => sub {[]}
 } => sub ($self, $event) {
   my $what = $event->text =~ s/\Pl//igr;
   $what = lc $what;

--- a/lib/Synergy/Reactor/GoodMorning.pm
+++ b/lib/Synergy/Reactor/GoodMorning.pm
@@ -3,7 +3,7 @@ use warnings;
 package Synergy::Reactor::GoodMorning;
 
 use Moose;
-with 'Synergy::Role::Reactor';
+with 'Synergy::Role::Reactor::CommandPost';
 
 use experimental qw(signatures lexical_subs);
 use namespace::clean;

--- a/lib/Synergy/Reactor/GoodMorning.pm
+++ b/lib/Synergy/Reactor/GoodMorning.pm
@@ -3,7 +3,8 @@ use warnings;
 package Synergy::Reactor::GoodMorning;
 
 use Moose;
-with 'Synergy::Role::Reactor::CommandPost';
+with 'Synergy::Role::Reactor',
+     'Synergy::Role::Reactor::CommandPost';
 
 use experimental qw(signatures lexical_subs);
 use namespace::clean;

--- a/lib/Synergy/Reactor/Linear.pm
+++ b/lib/Synergy/Reactor/Linear.pm
@@ -377,7 +377,7 @@ sub _handle_creation_event ($self, $event, $arg = {}) {
   $self->_with_linear_client($event, $code);
 }
 
-reaction new_issue => {
+responder new_issue => {
   exclusive => 1,
   targeted  => 1,
   matcher   => sub ($text, @) {
@@ -414,7 +414,7 @@ EOH
   $self->_handle_creation_event($event);
 };
 
-reaction ptn_blocked => {
+responder ptn_blocked => {
   targeted  => 1,
   exclusive => 1,
   matcher   => sub ($text, @) {

--- a/lib/Synergy/Reactor/Zendesk.pm
+++ b/lib/Synergy/Reactor/Zendesk.pm
@@ -1,5 +1,4 @@
-use v5.24;
-use warnings;
+use v5.28;
 package Synergy::Reactor::Zendesk;
 
 use Moose;

--- a/lib/Synergy/Role/DeduplicatesExpandos.pm
+++ b/lib/Synergy/Role/DeduplicatesExpandos.pm
@@ -1,4 +1,4 @@
-use v5.24.0;
+use v5.28.0;
 use warnings;
 package Synergy::Role::DeduplicatesExpandos;
 

--- a/lib/Synergy/Role/Reactor.pm
+++ b/lib/Synergy/Role/Reactor.pm
@@ -11,6 +11,8 @@ with 'Synergy::Role::HubComponent';
 
 sub start ($self) { }
 
+requires 'potential_reactions_to';
+
 sub resolve_name ($self, $name, $resolving_user) {
   $self->hub->user_directory->resolve_name($name, $resolving_user);
 }

--- a/lib/Synergy/Role/Reactor/CommandPost.pm
+++ b/lib/Synergy/Role/Reactor/CommandPost.pm
@@ -1,0 +1,23 @@
+package Synergy::Role::Reactor::CommandPost;
+
+use MooseX::Role::Parameterized;
+
+use experimental 'signatures';
+
+use Synergy::CommandPost ();
+use Synergy::PotentialReaction;
+
+role {
+  my $object = Synergy::CommandPost::Object->new;
+  method _commandpost => sub { $object };
+
+  method potential_reactions_to => sub ($self, $event) {
+    $self->_commandpost->potential_reactions_to($self, $event);
+  };
+
+  method help_entries => sub ($self) {
+    $self->_commandpost->_help_entries;
+  };
+};
+
+1;

--- a/t/commandpost.t
+++ b/t/commandpost.t
@@ -1,0 +1,54 @@
+#!perl
+use v5.28.0;
+use warnings;
+use experimental 'signatures';
+
+use Test::More;
+use Test::Deep;
+
+use lib 't/lib';
+
+use Synergy::Test::CommandPost;
+
+subtest "the absolute basics" => sub {
+  my $outpost = create_outpost(
+    [ command => foo => {} => tail_echoer ],
+  );
+
+  my $plan = $outpost->consider_targeted("foo bar");
+
+  $plan->cmp_prs(
+    methods(name => 'command-foo', is_exclusive => 1),
+    "command foo handles 'foo bar'",
+  );
+
+  $plan->cmp_results(
+    {
+      name    => 'command-foo',
+      result  => [ 'bar' ],
+    },
+  );
+};
+
+subtest "matchers" => sub {
+  my sub split_if_matching ($regex) {
+    return sub ($event) {
+      my $text = $event->text;
+      return unless $text =~ $regex;
+      return [ split //, $text ];
+    }
+  }
+
+  my $outpost = create_outpost(
+    [ reaction => demo => { matcher => split_if_matching(q{0}) } => tail_echoer ],
+  );
+
+  $outpost->consider_targeted("gorp")->cmp_prs("we won't react without matches");
+
+  $outpost->consider_targeted("g0rp")->cmp_results(
+    { name => 'reaction-demo', result => [ qw( g 0 r p ) ] },
+    'matcher sub determines args to reaction',
+  );
+};
+
+done_testing;

--- a/t/commandpost.t
+++ b/t/commandpost.t
@@ -63,15 +63,15 @@ subtest "matchers and parsers" => sub {
   }
 
   my $outpost = create_outpost(
-    [ reaction => demo => { matcher => split_if_matching(q{0}) } => tail_echoer ],
-    [ command  => demo => { parser  => split_if_matching(q{9}) } => tail_echoer ],
+    [ responder => demo => { matcher => split_if_matching(q{0}) } => tail_echoer ],
+    [ command   => demo => { parser  => split_if_matching(q{9}) } => tail_echoer ],
   );
 
   $outpost->consider_targeted("gorp")->cmp_prs("we won't react without matches");
 
   $outpost->consider_targeted("g0rp")->cmp_results(
-    { name => 'reaction-demo', result => [ qw( g 0 r p ) ] },
-    'matcher sub determines args to reaction',
+    { name => 'responder-demo', result => [ qw( g 0 r p ) ] },
+    'matcher sub determines args to responder',
   );
 
   $outpost->consider_targeted("demo g9rp")->cmp_results(

--- a/t/commandpost.t
+++ b/t/commandpost.t
@@ -39,6 +39,11 @@ subtest "aliases" => sub {
     { name => 'command-foo', result  => [ 'bar' ] },
   );
 
+  $outpost->consider_targeted("FOO bar")->cmp_results(
+    { name => 'command-foo', result  => [ 'bar' ] },
+    "commands match case insensitively, but args are not munged",
+  );
+
   # Right now, the name of the reaction comes from the name that matched,
   # rather than the name under which the command was declared.  This isn't
   # really the kind of thing to guarantee, so we'll allow either one here.

--- a/t/lib/Synergy/Test/CommandPost.pm
+++ b/t/lib/Synergy/Test/CommandPost.pm
@@ -1,0 +1,155 @@
+use v5.28.0;
+use warnings;
+package Synergy::Test::CommandPost;
+
+use Synergy::Event ();
+use Synergy::CommandPost ();
+use Synergy::Role::Reactor::CommandPost ();
+
+use experimental 'signatures';
+
+use Sub::Exporter -setup => {
+  exports => [ qw(
+    create_outpost
+
+    arg_echoer
+    tail_echoer
+
+    is_event is_channel is_reactor
+  ) ],
+  groups  => { default => [ '-all' ] },
+};
+
+package Synergy::CommandPost::TestOutpost::Plan {
+  use Moose;
+  use experimental 'signatures';
+
+  has event  => (is => 'ro', required => 1);
+  has _prs   => (is => 'ro', required => 1, init_arg => 'prs');
+
+  sub prs { $_[0]->_prs->@* }
+
+  sub reaction_results ($self) {
+    my $event   = $self->event;
+    my @results = map {; { name => $_->name, result => scalar $_->handle_event($event) } }
+                  $self->prs;
+
+    return @results;
+  }
+
+  sub cmp_prs ($self, @expect) {
+    my $desc = 'potential reactions met expectations';
+    $desc = pop @expect if ! ref $expect[-1];
+
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+    return Test::Deep::cmp_deeply(
+      [ $self->prs ],
+      [ @expect ],
+      $desc,
+    );
+  }
+
+  sub cmp_results ($self, @expect) {
+    my $desc = 'actual reaction results met expectations';
+    $desc = pop @expect if ! ref $expect[-1];
+
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+    return Test::Deep::cmp_deeply(
+      [ $self->reaction_results ],
+      [ @expect ],
+      $desc,
+    );
+  }
+
+  no Moose;
+}
+
+package Synergy::CommandPost::TestOutpost {
+  sub consider_targeted ($self, $text) {
+    my $event = Synergy::Test::CommandPost::_event($text);
+    $self->consider_event($event);
+  }
+
+  sub consider_untargeted ($self, $text) {
+    my $event = Synergy::Test::CommandPost::_event($text, { was_targeted => 0 });
+    $self->consider_event($event);
+  }
+
+  sub consider_event ($self, $event) {
+    my $R = bless [], "FakeReactor";
+
+    return Synergy::CommandPost::TestOutpost::Plan->new({
+      event => $event,
+      prs   => [ $self->commandpost->potential_reactions_to($R, $event) ],
+    });
+  }
+}
+
+sub is_reactor {
+  Test::Deep::any(
+    Test::Deep::obj_isa('FakeReactor'),
+    Test::Deep::code(sub ($got) { return $got->DOES('Synergy::Role::Reactor') }),
+  );
+}
+
+sub is_event { Test::Deep::obj_isa('Synergy::Event') }
+
+sub is_channel {
+  Test::Deep::code(sub ($got) { return $got->DOES('Synergy::Role::Channel') })
+}
+
+sub create_outpost (@todo) {
+  my (undef, undef, $line) = caller;
+  my $i = 1;
+  my $package = "Synergy::CommandPost::TestOutpost::Outpost$line\_" . $i++;
+
+  {
+    no strict 'refs';
+    @{"$package\::ISA"} = ('Synergy::CommandPost::TestOutpost');
+  }
+
+  my $commandpost = Synergy::CommandPost::Object->new;
+
+  Synergy::CommandPost->import(
+    { into => $package },
+    -default => { commandpost => $commandpost },
+  );
+
+  Sub::Install::install_sub({
+    code  => sub { $commandpost },
+    as    => 'commandpost',
+    into  => $package,
+  });
+
+  for my $todo (@todo) {
+    my ($func, @arg) = @$todo;
+
+    $package->can($func)->(@arg);
+  }
+
+  return $package;
+}
+
+sub arg_echoer { return sub { [ @_ ] }; }
+
+sub tail_echoer { return sub ($reactor, $channel, @tail) { [ @tail ]; } }
+
+require Synergy::Channel::Test;
+my $BOGUS_CHANNEL = Synergy::Channel::Test->new({
+  name => 'bogus-test-channel',
+});
+
+sub _event ($text, $arg = {}) {
+  return Synergy::Event->new({
+    type => 'message',
+    from_address => 'bogus-from',
+    # from_user => $from_user,
+    from_channel => $BOGUS_CHANNEL,
+    was_targeted => 1,
+    conversation_address => 'public',
+    %$arg,
+    text => $text,
+  });
+}
+
+1;

--- a/t/lib/Synergy/Test/CommandPost.pm
+++ b/t/lib/Synergy/Test/CommandPost.pm
@@ -38,8 +38,12 @@ package Synergy::CommandPost::TestOutpost::Plan {
   }
 
   sub cmp_prs ($self, @expect) {
-    my $desc = 'potential reactions met expectations';
-    $desc = pop @expect if ! ref $expect[-1];
+    my $desc  = @expect && ! ref $expect[-1]
+              ? (pop @expect)
+              : do {
+                  my (undef, $file, $line) = caller;
+                  "potential reactions met expectations ($file, $line)"
+                };
 
     local $Test::Builder::Level = $Test::Builder::Level + 1;
     return Test::Deep::cmp_deeply(
@@ -50,8 +54,12 @@ package Synergy::CommandPost::TestOutpost::Plan {
   }
 
   sub cmp_results ($self, @expect) {
-    my $desc = 'actual reaction results met expectations';
-    $desc = pop @expect if ! ref $expect[-1];
+    my $desc  = @expect && ! ref $expect[-1]
+              ? (pop @expect)
+              : do {
+                  my (undef, $file, $line) = caller;
+                  "actual reactions met expectations ($file, $line)"
+                };
 
     local $Test::Builder::Level = $Test::Builder::Level + 1;
     return Test::Deep::cmp_deeply(


### PR DESCRIPTION
1. I refactored CommandPost to make it a little (only a little) simpler
2. I wrote a testing library for testing CommandPost itself
3. I converted the Linear reactor to CommandPost
4. I added command aliases to CommandPost
5. I added "parsers" to commands; these probably need more work in the future