### PR TITLE
pager duty: add an alias 'alerts' map to 'incidents'

### DIFF
--- a/lib/Synergy/Reactor/PagerDuty.pm
+++ b/lib/Synergy/Reactor/PagerDuty.pm
@@ -231,7 +231,7 @@ EOH
       name      => 'incident-summary',
       method    => '_handle_incidents',
       targeted  => 1,
-      predicate => sub ($self, $e) { $e->text =~ /^incidents\s*$/i },
+      predicate => sub ($self, $e) { $e->text =~ /^(incidents|alerts)\s*$/in },
       help_entries => [
         { title => 'incidents', text => '*incidents*: list current active incidents' },
       ],


### PR DESCRIPTION
To often i find myself forgetting that the command is incidents and type
alerts.  Now i won't have that problem