### PR TITLE
Splitflap editor: fix input on Firefox

### DIFF
--- a/share/splitflap/editor.js
+++ b/share/splitflap/editor.js
@@ -68,6 +68,11 @@ const splitflapValues = {
   69: "⬜", // "White"
 };
 
+const splitFlapKeys = {};
+Object.keys(splitflapValues).forEach(
+  (key) => (splitFlapKeys[splitflapValues[key]] = key)
+);
+
 let representation = [];
 let workingRow;
 let firstElement;
@@ -340,6 +345,7 @@ window.onkeydown = (event) => {
       event.stopPropagation();
     }
   } else {
+    target.writeRaw(splitFlapKeys[event.key && event.key.toUpperCase()]);
     return;
   }
   if (event.key === " ") {


### PR DESCRIPTION
A recent Firefox update seems to have done _something_ to have broken
native input selecting option values by their text when typing at a
normal speed.  I didn't try very hard to track down what the change
in Firefox actually was, because it's almost lunch time on a Saturday.
Instead, let's just force the issue and not try to use native input
anymore.