### PR TITLE
Pusher/Twilio: send_message final argument should be optional

### DIFF
--- a/lib/Synergy/Channel/Pushover.pm
+++ b/lib/Synergy/Channel/Pushover.pm
@@ -44,7 +44,7 @@ sub send_message_to_user ($self, $user, $text, $alts = {}) {
   $self->send_message($where, $text, $alts);
 }
 
-sub send_message ($self, $target, $text, $alts) {
+sub send_message ($self, $target, $text, $alts = {}) {
   my $from;
 
   my $res = $self->http_post(

--- a/lib/Synergy/Channel/Twilio.pm
+++ b/lib/Synergy/Channel/Twilio.pm
@@ -127,7 +127,7 @@ sub send_message_to_user ($self, $user, $text, $alts = {}) {
   $self->send_message($phone, $text, $alts);
 }
 
-sub send_message ($self, $target, $text, $alts) {
+sub send_message ($self, $target, $text, $alts = {}) {
   my $from = $self->from;
 
   for my $code (sort { length $b <=> length $a } keys $self->numbers->%*) {


### PR DESCRIPTION
Otherwise if you `synergy upgrade` from Twilio, when it restarts it'll keep crashing trying to send the "I updated!" message.

Oops!