### PR TITLE
InABox: Update datacentre default in Australia

### DIFF
--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -622,7 +622,7 @@ sub _region_for_user ($self, $user) {
   my $tz = $user->time_zone;
   my ($area) = split '/', $tz;
   return
-    $area eq 'Australia' ? 'sfo3' :
+    $area eq 'Australia' ? 'syd1' :
     $area eq 'Europe'    ? 'ams3' :
                            'nyc3';
 }


### PR DESCRIPTION
DigitalOcean now have a datacentre in Sydney and the images are being copied there.