### PR TITLE
Synergy::Hub: Track in-flight http requests

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use 5.034000;
+use 5.032000;
 
 use ExtUtils::MakeMaker 6.78;
 


### PR DESCRIPTION
This makes it so that Synergy::Channel::Test's is_exhausted can take into account whether or not a reactor is waiting on an external HTTP service before responding.

Without this, `$channel->is_exhausted` would return true, even if a reactor hadn't had a chance to respond yet.