### PR TITLE
convert preference properties to async/await (and associated work)

### DIFF
--- a/lib/Synergy/Hub.pm
+++ b/lib/Synergy/Hub.pm
@@ -196,8 +196,7 @@ sub handle_event ($self, $event) {
         ]);
 
         if ($args[0] isa 'Synergy::X' && $args[0]->is_public) {
-          $event->reply($args[0]->message);
-          return
+          return $event->reply($args[0]->message);
         }
 
         $event->error_reply("My $rname reactor crashed (in the background) while handling your message.  Sorry!");

--- a/lib/Synergy/Reactor/Clox.pm
+++ b/lib/Synergy/Reactor/Clox.pm
@@ -12,6 +12,7 @@ use Synergy::CommandPost;
 use experimental qw(signatures lexical_subs);
 
 use DateTime;
+use Future::AsyncAwait;
 use List::Util qw(first uniq);
 use Synergy::Util qw(parse_date_for_user);
 use Time::Duration::Parse;
@@ -25,8 +26,8 @@ __PACKAGE__->add_preference(
   name        => 'include-aelt',
   help        => "Whether or not to include AELT in the output",
   description => "Whether or not to include AELT in the output",
-  describer   => sub ($value) { $value ? 1 : 0 },
-  validator   => sub ($self, $value, $event) {
+  describer   => async sub ($value) { $value ? 1 : 0 },
+  validator   => async sub ($self, $value, $event) {
     return(($value ? 1 : 0), undef); # Should write a generic bool/yes/no.
   },
   default     => 0,

--- a/lib/Synergy/Reactor/Clox.pm
+++ b/lib/Synergy/Reactor/Clox.pm
@@ -26,7 +26,7 @@ __PACKAGE__->add_preference(
   name        => 'include-aelt',
   help        => "Whether or not to include AELT in the output",
   description => "Whether or not to include AELT in the output",
-  describer   => async sub ($value) { $value ? 1 : 0 },
+  describer   => async sub ($self, $value) { $value ? 1 : 0 },
   validator   => async sub ($self, $value, $event) {
     return(($value ? 1 : 0), undef); # Should write a generic bool/yes/no.
   },

--- a/lib/Synergy/Reactor/DiagnosticEvents.pm
+++ b/lib/Synergy/Reactor/DiagnosticEvents.pm
@@ -21,7 +21,7 @@ command 'diag-die' => {
 command 'diag-die-x' => {
   help => '*diag-die-x*: reacts by throwing a public Synergy::X exception',
 } => async sub ($self, $event, $rest) {
-  Synergy::X->throw_public("This exception was caused on purpose via Synergy::X.");
+  Synergy::X->throw_public("This exception was caused on purpose via a Synergy::X thrown by diag-die-x.");
 };
 
 1;

--- a/lib/Synergy/Reactor/GitLab.pm
+++ b/lib/Synergy/Reactor/GitLab.pm
@@ -15,6 +15,7 @@ use namespace::clean;
 use DateTime::Format::ISO8601;
 use Digest::MD5 qw(md5_hex);
 use Future 0.36;  # for ->retain
+use Future::AsyncAwait;
 use IO::Async::Timer::Periodic;
 use JSON::MaybeXS;
 use Lingua::EN::Inflect qw(PL_N PL_V);
@@ -1087,7 +1088,7 @@ sub mr_report ($self, $who, $arg = {}) {
 
 __PACKAGE__->add_preference(
   name      => 'user-id',
-  validator => sub ($self, $value, @) {
+  validator => async sub ($self, $value, @) {
     return $value if $value =~ /\A[0-9]+\z/;
     return (undef, "Your user-id must be a positive integer.")
   },

--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -510,7 +510,7 @@ sub _region_for_user ($self, $user) {
 
 __PACKAGE__->add_preference(
   name      => 'version',
-  validator => sub ($self, $value, @) {
+  validator => async sub ($self, $value, @) {
     # Clearing is fine; we'll pick up the default elsewhere
     return undef unless defined $value;
 
@@ -531,7 +531,7 @@ __PACKAGE__->add_preference(
 
 __PACKAGE__->add_preference(
   name      => 'datacentre',
-  validator => sub ($self, $value, @) {
+  validator => async sub ($self, $value, @) {
     # Clearing is fine; we'll pick up the default elsewhere
     return undef unless defined $value;
 

--- a/lib/Synergy/Reactor/Linear.pm
+++ b/lib/Synergy/Reactor/Linear.pm
@@ -1088,7 +1088,7 @@ responder ptn_blocked => {
 
 __PACKAGE__->add_preference(
   name      => 'api-token',
-  describer => async sub ($value) { defined $value ? "<redacted>" : '<undef>' },
+  describer => async sub ($self, $value) { defined $value ? "<redacted>" : '<undef>' },
   default   => undef,
   validator => async sub ($self, $value, $event) {
     $value =~ s/^\s*|\s*$//g;
@@ -1109,7 +1109,7 @@ __PACKAGE__->add_preference(
   name        => 'default-team',
   help        => "Default team in Linear. Make sure to enter the three letter team key.",
   description => "Default team for your Linear issues",
-  describer   => async sub ($value) { $value // '<none>' },
+  describer   => async sub ($self, $value) { $value // '<none>' },
   validator   => async sub ($self, $value, $event) {
     # Look, this is *terrible*.  _with_linear_client will return a reply
     # future, if we failed.  Otherwise it returns the result of the called sub,

--- a/lib/Synergy/Reactor/Linear.pm
+++ b/lib/Synergy/Reactor/Linear.pm
@@ -1088,9 +1088,9 @@ responder ptn_blocked => {
 
 __PACKAGE__->add_preference(
   name      => 'api-token',
-  describer => sub ($value) { return defined $value ? "<redacted>" : '<undef>' },
+  describer => async sub ($value) { defined $value ? "<redacted>" : '<undef>' },
   default   => undef,
-  validator => sub ($self, $value, $event) {
+  validator => async sub ($self, $value, $event) {
     $value =~ s/^\s*|\s*$//g;
 
     unless ($value =~ /^lin_api/) {
@@ -1109,11 +1109,8 @@ __PACKAGE__->add_preference(
   name        => 'default-team',
   help        => "Default team in Linear. Make sure to enter the three letter team key.",
   description => "Default team for your Linear issues",
-  describer   => sub ($value) {
-    return '<none>' unless defined $value;
-    return $value;
-  },
-  validator   => sub ($self, $value, $event) {
+  describer   => async sub ($value) { $value // '<none>' },
+  validator   => async sub ($self, $value, $event) {
     # Look, this is *terrible*.  _with_linear_client will return a reply
     # future, if we failed.  Otherwise it returns the result of the called sub,
     # which here is the expected (ok, error) tuple.  We need to detect the
@@ -1140,7 +1137,7 @@ __PACKAGE__->add_preference(
   name      => 'agenda-shows-assigned',
   help      => "Whether the agenda command shows assigned items or not (yes/no)",
   default   => 1,
-  validator => sub ($self, $value, @) { return bool_from_text($value) },
+  validator => async sub ($self, $value, @) { return bool_from_text($value) },
 );
 
 1;

--- a/lib/Synergy/Reactor/Linear.pm
+++ b/lib/Synergy/Reactor/Linear.pm
@@ -1110,6 +1110,7 @@ __PACKAGE__->add_preference(
   help        => "Default team in Linear. Make sure to enter the three letter team key.",
   description => "Default team for your Linear issues",
   describer   => sub ($value) {
+    return '<none>' unless defined $value;
     return $value;
   },
   validator   => sub ($self, $value, $event) {

--- a/lib/Synergy/Reactor/Page.pm
+++ b/lib/Synergy/Reactor/Page.pm
@@ -98,7 +98,7 @@ END
 
 __PACKAGE__->add_preference(
   name      => 'voice-page',
-  validator => sub ($self, $value, @) { return bool_from_text($value) },
+  validator => async sub ($self, $value, @) { return bool_from_text($value) },
   default   => 1,
   help      => "Should paging try make a voice call instead of a text message?",
   description => "Should paging try make a voice call instead of a text message?",

--- a/lib/Synergy/Reactor/PagerDuty.pm
+++ b/lib/Synergy/Reactor/PagerDuty.pm
@@ -1069,7 +1069,7 @@ __PACKAGE__->add_preference(
 
 __PACKAGE__->add_preference(
   name      => 'api-token',
-  describer => async sub ($value) { defined $value ? "<redacted>" : '<undef>' },
+  describer => async sub ($self, $value) { defined $value ? "<redacted>" : '<undef>' },
   default   => undef,
   validator => async sub ($self, $token, $event) {
     $token =~ s/^\s*|\s*$//g;

--- a/lib/Synergy/Reactor/PagerDuty.pm
+++ b/lib/Synergy/Reactor/PagerDuty.pm
@@ -1236,9 +1236,10 @@ __PACKAGE__->add_preference(
         $event->reply(
           "Great! I found the PagerDuty user for $email, and will also set your PD user id to $id."
         );
-        $self->set_user_preference($event->from_user, 'user-id', $id);
 
-        return Future->done;
+        $self->set_user_preference($event->from_user, 'user-id', $id)->then(sub {
+          Future->done
+        });
       })
       ->else(sub ($err) {
         $ret_err = $err;

--- a/lib/Synergy/Reactor/PagerDuty.pm
+++ b/lib/Synergy/Reactor/PagerDuty.pm
@@ -177,9 +177,11 @@ help maint => reformat_help(<<~"EOH");
   Conveniences for managing PagerDuty's "maintenance mode", aka "silence all
   the alerts because everything is on fire."
 
-  • *maint status*: show current maintenance state • *maint start*: enter
-  maintenance mode. All alerts are now silenced! Also acks • *maint end*,
-  *demaint*, *unmaint*, *stop*: leave maintenance mode. Alerts are noisy again!
+  • *maint status*: show current maintenance state
+  • *maint start*: enter maintenance mode. All alerts are now silenced! Also
+  acks
+  • *maint end*, *demaint*, *unmaint*, *stop*: leave maintenance mode. Alerts
+  are noisy again!
 
   When you leave maintenance mode, any alerts that happened during it, or even
   shortly before it, will be marked resolved.  If you don't want that, say

--- a/lib/Synergy/Reactor/Preferences.pm
+++ b/lib/Synergy/Reactor/Preferences.pm
@@ -50,7 +50,7 @@ command set => { # allow_empty_help => 1,  # provided by preferences above
     return await $event->error_reply("I didn't understand that use of set.");
   }
 
-  return $self->_set_pref($event, $who, $pref_name, $pref_value);
+  return await $self->_set_pref($event, $who, $pref_name, $pref_value);
 };
 
 command clear => { # allow_empty_help => 1,  # provided by preferences above
@@ -68,7 +68,7 @@ command clear => { # allow_empty_help => 1,  # provided by preferences above
   return $event->error_reply("You can't pass a value to 'clear'")
     if $rest;
 
-  return $self->_set_pref($event, $who, $pref_name, undef);
+  return await $self->_set_pref($event, $who, $pref_name, undef);
 };
 
 responder list => { # allow_empty_help => 1,  # provided by preferences above
@@ -99,7 +99,7 @@ responder list => { # allow_empty_help => 1,  # provided by preferences above
   }
 
   chomp $text;
-  $event->reply($text);
+  return await $event->reply($text);
 };
 
 responder dump => { # allow_empty_help => 1,  # provided by preferences above
@@ -144,12 +144,12 @@ responder dump => { # allow_empty_help => 1,  # provided by preferences above
   return await $event->reply("Preferences for $name: ```$prefs```");
 };
 
-sub _set_pref ($self, $event, $who, $full_name, $pref_value) {
+async sub _set_pref ($self, $event, $who, $full_name, $pref_value) {
   return unless $who;
   $who =~ s/[’']s$//;
 
   my $user = $self->hub->user_directory->resolve_name($who, $event->from_user);
-  return $event->error_reply("Sorry, I couldn't find a user for <$who>")
+  return await $event->error_reply("Sorry, I couldn't find a user for <$who>")
     unless $user;
 
   my ($comp_name, $pref_name) = split /\./, $full_name, 2;
@@ -165,7 +165,7 @@ sub _set_pref ($self, $event, $who, $full_name, $pref_value) {
   return unless $component;
 
   if ($user != $event->from_user && ! $event->from_user->is_master) {
-    return $event->error_reply(
+    return await $event->error_reply(
       "Sorry, only master users can set preferences for other people"
     );
   }
@@ -174,6 +174,8 @@ sub _set_pref ($self, $event, $who, $full_name, $pref_value) {
     unless $component->can('set_preference');
 
   $component->set_preference($user, $pref_name, $pref_value, $event);
+
+  return;
 }
 
 sub _error_no_prefs ($self, $event, $component) {

--- a/lib/Synergy/Reactor/Preferences.pm
+++ b/lib/Synergy/Reactor/Preferences.pm
@@ -173,7 +173,7 @@ async sub _set_pref ($self, $event, $who, $full_name, $pref_value) {
   return $self->_error_no_prefs($event, $comp_name)
     unless $component->can('set_preference');
 
-  $component->set_preference($user, $pref_name, $pref_value, $event);
+  await $component->set_preference($user, $pref_name, $pref_value, $event);
 
   return;
 }

--- a/lib/Synergy/Reactor/Preferences.pm
+++ b/lib/Synergy/Reactor/Preferences.pm
@@ -132,9 +132,10 @@ responder dump => { # allow_empty_help => 1,  # provided by preferences above
   for my $component (@components) {
     for my $pref_name (sort $component->preference_names) {
       my $full_name = $component->preference_namespace . q{.} . $pref_name;
+      my $desc      = await $component->describe_user_preference($for_user, $pref_name);
+      $desc //= '(error)';
 
-      push @pref_strings,
-        "$full_name: " . ($component->describe_user_preference($for_user, $pref_name) // '(error)');
+      push @pref_strings, "$full_name: $desc";
     }
   }
 

--- a/lib/Synergy/Reactor/Preferences.pm
+++ b/lib/Synergy/Reactor/Preferences.pm
@@ -7,113 +7,142 @@ use Try::Tiny;
 use Synergy::Logger '$Logger';
 use utf8;
 
-with 'Synergy::Role::Reactor::EasyListening';
+with 'Synergy::Role::Reactor::CommandPost';
+
+use Future::AsyncAwait;
+use Synergy::CommandPost;
+use Synergy::Util qw(reformat_help);
 
 use experimental qw(signatures);
 use namespace::clean;
 
-sub listener_specs {
-  return (
-    {
-      # This is idiotic.  This has to exist for help. I have only myself to
-      # blame. -- rjbs, 2019-07-24
-      name => 'preferences',
-      method    => sub {},
-      exclusive => 1,
-      predicate => sub { return; },
-      help_entries => [
-        (map {; +{ title => $_, unlisted => 1, text => "See *help preferences*" } }
-          qw( clear dump prefs set show )),
-        {
-          title => 'preferences',
-          text  => <<'EOH' =~ s/(\S)\n([^\s•])/$1 $2/rg,
-Different components of Synergy provide user-level preferences that range from
-the vital (like your real name) to the … less vital.
+help preferences => reformat_help(<<~"EOH");
+  Different components of Synergy provide user-level preferences that range
+  from the vital (like your real name) to the … less vital.
 
-To know what preferences you can or have already set, try:
+  To know what preferences you can or have already set, try:
 
-• *list all preferences*: this, obviously, lists all preferences you can set
-• *help preference `PREF`*: show help for the preference
-• *dump my preferences*: this shows you all your preferences
-• *dump preferences for `USER`*: see another user's prefs
+  • *list all preferences*: this, obviously, lists all preferences you can set
+  • *help preference `PREF`*: show help for the preference
+  • *dump my preferences*: this shows you all your preferences
+  • *dump preferences for `USER`*: see another user's prefs
 
-To set your preferences:
+  To set your preferences:
 
-• *set my `PREF` to `VALUE`*: set a preference
-• *clear my `PREF`*: unset a preference and go back to the default
+  • *set my `PREF` to `VALUE`*: set a preference
+  • *clear my `PREF`*: unset a preference and go back to the default
 
-If you're an administrator, you can also…
+  If you're an administrator, you can also…
 
-• *set `USER`'s `PREF` to `VALUE`*: set another user's preferences
-• *clear `USER`'s `PREF`*: unset some other user's preference
-EOH
-        },
-      ],
-    },
-    {
-      name      => 'set',
-      method    => 'handle_set',
-      exclusive => 1,
-      targeted  => 1,
-      predicate => sub ($self, $e) { $e->text =~ /\Aset\s+(my|\w+[’']s)/in },
-      allow_empty_help => 1,  # provided by preferences above
-    },
-    {
-      name      => 'clear',
-      method    => 'handle_clear',
-      exclusive => 1,
-      targeted  => 1,
-      predicate => sub ($self, $e) { $e->text =~ /\Aclear\s+(my|\w+[’']s)/in },
-      allow_empty_help => 1,  # provided by preferences above
-    },
-    {
-      name      => 'list_all_preferences',
-      method    => 'handle_list',
-      exclusive => 1,
-      targeted  => 1,
-      predicate => sub ($self, $e) {
-        $e->text =~ /\Alist(\s+all)?\s+(settings|pref(erence)s?)\s*\z/i;
-      },
-      allow_empty_help => 1,  # provided by preferences above
-    },
-    {
-      name      => 'dump',
-      method    => 'handle_dump',
-      exclusive => 1,
-      targeted  => 1,
-      predicate => sub ($self, $e) {
-        return 1 if $e->text =~ /\Apref(erence)?s\z/in;
-        return 1 if $e->text =~ /\A(dump|show)(\s+my)?\s+(settings|pref(erence)?s)/in;
-        return 1 if $e->text =~ /\A(dump|show)\s+(settings|pref(erence)?s)\s+for/in;
-        return;
-      },
-      allow_empty_help => 1,  # provided by preferences above
-    }
-  );
-}
+  • *set `USER`'s `PREF` to `VALUE`*: set another user's preferences
+  • *clear `USER`'s `PREF`*: unset some other user's preference
+  EOH
 
-sub handle_set ($self, $event) {
+command set => { # allow_empty_help => 1,  # provided by preferences above
+} => async sub ($self, $event, $rest) {
   my ($who, $pref_name, $pref_value) =
     $event->text =~ m{\A set \s+ (my|\w+[’']s) \s+      # set my
                       ([-_a-z0-9]+  \.   [-_a-z0-9]+)   # component.pref
                       (?:\s+to|:)? \s+ (.*)             # (to or :) value
                      }ix;
 
-  return $self->_set_pref($event, $who, $pref_name, $pref_value);
-}
+  unless ($who) {
+    return await $event->error_reply("I didn't understand that use of set.");
+  }
 
-sub handle_clear ($self, $event) {
+  return $self->_set_pref($event, $who, $pref_name, $pref_value);
+};
+
+command clear => { # allow_empty_help => 1,  # provided by preferences above
+} => async sub ($self, $event, $rest) {
   my ($who, $pref_name, $rest) =
     $event->text =~ m{\A clear \s+ (my|\w+[’']s) \s+    # set my
                       ([-_a-z0-9]+  \.  [-_a-z0-9]+)    # component.pref
                       \s* (.+)?
                      }ix;
 
+  unless ($who) {
+    return await $event->error_reply("I didn't understand that use of clear.");
+  }
+
   return $event->error_reply("You can't pass a value to 'clear'")
     if $rest;
 
   return $self->_set_pref($event, $who, $pref_name, undef);
-}
+};
+
+responder list => { # allow_empty_help => 1,  # provided by preferences above
+  exclusive => 1,
+  targeted  => 1,
+  matcher   => sub ($text, @) {
+    return [] if $text =~ /\Alist(\s+all)?\s+(settings|pref(erence)?s)\s*\z/i;
+    return;
+  },
+} => async sub ($self, $event) {
+  $event->mark_handled;
+
+  my @sources = map {; [ $_->preference_namespace, $_ ] }
+    $self->hub->user_directory,
+    grep {; $_->does('Synergy::Role::HasPreferences') } $self->hub->reactors;
+
+  my $text = qq{*Known preferences are:*\n};
+  for my $source (sort { $a->[0] cmp $b->[0] } @sources) {
+    my ($ns, $has_pref) = @$source;
+
+    my $help = $has_pref->preference_help;
+    for my $key (sort keys %$help) {
+      $text .= sprintf "*%s.%s* - %s\n",
+        $ns,
+        $key,
+        $help->{$key}{description} // 'mystery preference';
+    }
+  }
+
+  chomp $text;
+  $event->reply($text);
+};
+
+responder dump => { # allow_empty_help => 1,  # provided by preferences above
+  exclusive => 1,
+  targeted  => 1,
+  matcher   => sub ($text, @) {
+    return [ 'me' ] if $text =~ /\Apref(erence)?s\z/in;
+    return [ 'me' ] if $text =~ /\A(dump|show)(\s+my)?\s+(settings|pref(erence)?s)/in;
+    return [ $1   ] if $text =~ /\A(?:dump|show)\s+(?:settings|pref(?:erence)?s)\s+for\s+(\s+)\s*\z/i;
+    return;
+  },
+} => async sub ($self, $event, $who) {
+  $event->mark_handled;
+
+  my $for_user = $self->resolve_name($who, $event->from_user);
+
+  unless ($for_user) {
+    return await $event->error_reply(qq!I don't know who "$who" is!);
+  }
+
+  my @pref_strings;
+  my $hub = $self->hub;
+
+  my @components = map  {; $_->[0]                                   }
+                   sort {; $a->[1] cmp $b->[1]                       }
+                   map  {; [ $_, fc $_->preference_namespace ]       }
+                   grep {; $_->does('Synergy::Role::HasPreferences') }
+                   ($hub->user_directory, $hub->channels, $hub->reactors);
+
+  for my $component (@components) {
+    for my $pref_name (sort $component->preference_names) {
+      my $full_name = $component->preference_namespace . q{.} . $pref_name;
+
+      push @pref_strings,
+        "$full_name: " . ($component->describe_user_preference($for_user, $pref_name) // '(error)');
+    }
+  }
+
+  my $prefs = join "\n", @pref_strings;
+  my $name = $for_user->username;
+
+  return await $event->reply("Preferences for $name: ```$prefs```");
+};
 
 sub _set_pref ($self, $event, $who, $full_name, $pref_value) {
   return unless $who;
@@ -147,68 +176,9 @@ sub _set_pref ($self, $event, $who, $full_name, $pref_value) {
   $component->set_preference($user, $pref_name, $pref_value, $event);
 }
 
-sub handle_dump ($self, $event) {
-  my ($who) = $event->text =~ /\A(?:show|dump)\s+pref(?:erence)?s\s+for\s+(\w+)/i;
-  $who //= 'me';
-
-  my $for_user = $self->resolve_name($who, $event->from_user);
-  unless ($for_user) {
-    $event->mark_handled;
-    return $event->error_reply(qq!I don't know who "$who" is!);
-  }
-
-  my @pref_strings;
-  my $hub = $self->hub;
-
-  my @components = map  {; $_->[0]                                   }
-                   sort {; $a->[1] cmp $b->[1]                       }
-                   map  {; [ $_, fc $_->preference_namespace ]       }
-                   grep {; $_->does('Synergy::Role::HasPreferences') }
-                   ($hub->user_directory, $hub->channels, $hub->reactors);
-
-  for my $component (@components) {
-    for my $pref_name (sort $component->preference_names) {
-      my $full_name = $component->preference_namespace . q{.} . $pref_name;
-
-      push @pref_strings,
-        "$full_name: " .  $component->describe_user_preference($for_user, $pref_name)
-    }
-  }
-
-  my $prefs = join "\n", @pref_strings;
-  my $name = $for_user->username;
-
-  $event->mark_handled;
-  $event->reply("Preferences for $name: ```$prefs```");
-}
-
 sub _error_no_prefs ($self, $event, $component) {
   $event->mark_handled;
   $event->error_reply("<$component> does not appear to have preferences");
-}
-
-sub handle_list ($self, $event) {
-  my @sources = map {; [ $_->preference_namespace, $_ ] }
-    $self->hub->user_directory,
-    grep {; $_->does('Synergy::Role::HasPreferences') } $self->hub->reactors;
-
-  my $text = qq{*Known preferences are:*\n};
-  for my $source (sort { $a->[0] cmp $b->[0] } @sources) {
-    my ($ns, $has_pref) = @$source;
-
-    my $help = $has_pref->preference_help;
-    for my $key (sort keys %$help) {
-      $text .= sprintf "*%s.%s* - %s\n",
-        $ns,
-        $key,
-        $help->{$key}{description} // 'mystery preference';
-    }
-  }
-
-  $event->mark_handled;
-
-  chomp $text;
-  $event->reply($text);
 }
 
 1;

--- a/lib/Synergy/Reactor/RememberTheMilk.pm
+++ b/lib/Synergy/Reactor/RememberTheMilk.pm
@@ -264,13 +264,13 @@ command milkauth => {
 
 __PACKAGE__->add_preference(
   name      => 'api-token',
-  validator => sub ($self, $value, @) {
+  validator => async sub ($self, $value, @) {
     return (undef, "You can only set your API token with the milkauth command.")
       if defined $value;
 
     return (undef, undef);
   },
-  describer => sub ($v) { return defined $v ? "<redacted>" : '<undef>' },
+  describer => async sub ($v) { defined $v ? "<redacted>" : '<undef>' },
   default   => undef,
 );
 

--- a/lib/Synergy/Reactor/RememberTheMilk.pm
+++ b/lib/Synergy/Reactor/RememberTheMilk.pm
@@ -257,7 +257,7 @@ command milkauth => {
 
   my $token = $rsp->get('auth')->{token};
 
-  my $got = $self->set_user_preference($user, 'api-token', $token);
+  my $got = await $self->set_user_preference($user, 'api-token', $token);
 
   return await $event->reply("You're authenticated!");
 };

--- a/lib/Synergy/Reactor/RememberTheMilk.pm
+++ b/lib/Synergy/Reactor/RememberTheMilk.pm
@@ -270,7 +270,7 @@ __PACKAGE__->add_preference(
 
     return (undef, undef);
   },
-  describer => async sub ($v) { defined $v ? "<redacted>" : '<undef>' },
+  describer => async sub ($self, $v) { defined $v ? "<redacted>" : '<undef>' },
   default   => undef,
 );
 

--- a/lib/Synergy/Reactor/TimeClock.pm
+++ b/lib/Synergy/Reactor/TimeClock.pm
@@ -14,6 +14,7 @@ use Synergy::Logger '$Logger';
 use Synergy::Util qw(bool_from_text describe_business_hours);
 
 use DBI;
+use Future::AsyncAwait;
 use IO::Async::Timer::Periodic;
 use List::Util qw(max);
 
@@ -454,7 +455,7 @@ sub check_for_shift_changes ($self) {
 
 __PACKAGE__->add_preference(
   name      => 'suppress-reports',
-  validator => sub ($self, $value, @) { return bool_from_text($value) },
+  validator => async sub ($self, $value, @) { return bool_from_text($value) },
   default   => 0,
 );
 

--- a/lib/Synergy/Reactor/Todo.pm
+++ b/lib/Synergy/Reactor/Todo.pm
@@ -157,7 +157,7 @@ __PACKAGE__->add_preference(
   name        => 'password',
   help        => "The password to use in accessing your todo list",
   description => "The password to use in accessing your todo list",
-  describer   => async sub ($value) { defined $value ? '<redacted>' : '<unset>' },
+  describer   => async sub ($self, $value) { defined $value ? '<redacted>' : '<unset>' },
   validator   => async sub ($self, $value, $event) {
     return ($value, undef);
   },
@@ -168,7 +168,7 @@ __PACKAGE__->add_preference(
   name        => 'calendar-user',
   help        => "The calendar user where you store your todos",
   description => "The calendar user where you store your todos",
-  describer   => async sub ($value) { $value // '<unset>' },
+  describer   => async sub ($self, $value) { $value // '<unset>' },
   validator   => async sub ($self, $value, $event) {
     return ($value, undef);
   },
@@ -179,7 +179,7 @@ __PACKAGE__->add_preference(
   name        => 'calendar-id',
   help        => "The calendar id where you store your todos",
   description => "The calendar id where you store your todos",
-  describer   => async sub ($value) { $value // '<unset>' },
+  describer   => async sub ($self, $value) { $value // '<unset>' },
   validator   => async sub ($self, $value, $event) {
     return ($value, undef);
   },

--- a/lib/Synergy/Reactor/Todo.pm
+++ b/lib/Synergy/Reactor/Todo.pm
@@ -14,6 +14,7 @@ use namespace::clean;
 use Data::GUID qw(guid_string);
 use DateTime;
 use Encode qw( encode );
+use Future::AsyncAwait;
 use MIME::Base64;
 use Synergy::Logger '$Logger';
 
@@ -156,8 +157,8 @@ __PACKAGE__->add_preference(
   name        => 'password',
   help        => "The password to use in accessing your todo list",
   description => "The password to use in accessing your todo list",
-  describer   => sub ($value) { defined $value ? '<redacted>' : '<unset>' },
-  validator   => sub ($self, $value, $event) {
+  describer   => async sub ($value) { defined $value ? '<redacted>' : '<unset>' },
+  validator   => async sub ($self, $value, $event) {
     return ($value, undef);
   },
   default     => undef,
@@ -167,8 +168,8 @@ __PACKAGE__->add_preference(
   name        => 'calendar-user',
   help        => "The calendar user where you store your todos",
   description => "The calendar user where you store your todos",
-  describer   => sub ($value) { $value // '<unset>' },
-  validator   => sub ($self, $value, $event) {
+  describer   => async sub ($value) { $value // '<unset>' },
+  validator   => async sub ($self, $value, $event) {
     return ($value, undef);
   },
   default     => undef,
@@ -178,8 +179,8 @@ __PACKAGE__->add_preference(
   name        => 'calendar-id',
   help        => "The calendar id where you store your todos",
   description => "The calendar id where you store your todos",
-  describer   => sub ($value) { $value // '<unset>' },
-  validator   => sub ($self, $value, $event) {
+  describer   => async sub ($value) { $value // '<unset>' },
+  validator   => async sub ($self, $value, $event) {
     return ($value, undef);
   },
   default     => undef,

--- a/lib/Synergy/Reactor/Zendesk.pm
+++ b/lib/Synergy/Reactor/Zendesk.pm
@@ -25,7 +25,7 @@ use Synergy::Logger '$Logger';
 
 __PACKAGE__->add_preference(
   name      => 'staff-email-address',
-  validator => sub ($self, $value, @) { return $value =~ /@/ ? $value : undef },
+  validator => async sub ($self, $value, @) { return $value =~ /@/ ? $value : undef },
   description => 'Your staff email address in Zendesk',
 );
 

--- a/lib/Synergy/Role/HasPreferences.pm
+++ b/lib/Synergy/Role/HasPreferences.pm
@@ -138,17 +138,19 @@ role {
     die "unknown pref: $pref_name"
       unless $self->is_known_preference($pref_name);
 
-    my $spec = $pref_specs{ $pref_name };
-    my $default = $spec->{default};
-    $default = $default->() if $default && ref $default eq 'CODE';
+    my sub default () {
+      my $default = $pref_specs{$pref_name}{default};
+      $default = $default->() if $default && ref $default eq 'CODE';
+      return $default;
+    }
 
     my $username = blessed $user ? $user->username : $user;
     return unless $username;
 
     my $user_prefs = $all_user_prefs{$username};
 
-    return $default unless $user_prefs && exists $user_prefs->{$pref_name};
-    return $user_prefs->{$pref_name} // $default;
+    return default() unless $user_prefs && exists $user_prefs->{$pref_name};
+    return $user_prefs->{$pref_name} // default();
   };
 
   method set_user_preference => sub ($self, $user, $pref_name, $value) {

--- a/lib/Synergy/Role/HasPreferences.pm
+++ b/lib/Synergy/Role/HasPreferences.pm
@@ -164,13 +164,7 @@ role {
 
     my $uprefs = $all_user_prefs{$username};
 
-    # This is necessary if the default value is an empty arrayref or something.
-    my $default = $spec->{default};
-    if ($default && ref $default eq 'CODE') {
-      $default = $default->();
-    }
-
-    $uprefs->{$pref_name} = $value // $default;
+    $uprefs->{$pref_name} = $value;
     delete $uprefs->{$pref_name} unless defined $uprefs->{$pref_name};
 
     $spec->{after_set}->($self, $username, $uprefs->{$pref_name});

--- a/lib/Synergy/Role/HasPreferences.pm
+++ b/lib/Synergy/Role/HasPreferences.pm
@@ -56,7 +56,7 @@ role {
       $Logger->log("couldn't get value for preference $pref_name: $@");
     }
 
-    return await $pref_specs{$pref_name}->{describer}->($val);
+    return await $pref_specs{$pref_name}->{describer}->($self, $val);
   };
 
   method preference_help => sub ($self) {
@@ -74,7 +74,7 @@ role {
   #   description => "a pref with a name",
   #   default     => value,
   #   validator   => async sub ($self, $val, $event) {},
-  #   describer   => async sub ($val) {},
+  #   describer   => async sub ($self, $val) {},
   #   after_set   => async sub ($self, $username, $value) {},
   # }
   #
@@ -89,7 +89,7 @@ role {
 
     die "preference $name already exists in $class" if $pref_specs{$name};
 
-    $spec{describer} //= async sub ($value) { return $value // '<undef>' };
+    $spec{describer} //= async sub ($self, $value) { return $value // '<undef>' };
     $spec{after_set} //= async sub ($self, $username, $value) {};
 
     $pref_specs{$name} = \%spec;

--- a/lib/Synergy/Role/HasPreferences.pm
+++ b/lib/Synergy/Role/HasPreferences.pm
@@ -47,7 +47,7 @@ role {
   method preference_names    => sub             { sort keys %pref_specs     };
   method is_known_preference => sub ($, $name)  { exists $pref_specs{$name} };
 
-  method describe_user_preference => sub ($self, $user, $pref_name) {
+  method describe_user_preference => async sub ($self, $user, $pref_name) {
     my $val;
 
     my $ok = try { $val = $self->get_user_preference($user, $pref_name); 1 };
@@ -95,7 +95,6 @@ role {
     $pref_specs{$name} = \%spec;
   };
 
-
   method set_preference => async sub ($self, $user, $pref_name, $value, $event) {
     $event->mark_handled;
 
@@ -114,7 +113,7 @@ role {
     }
 
     my $got  = await $self->set_user_preference($user, $pref_name, $actual_value);
-    my $desc = $self->describe_user_preference($user, $pref_name);
+    my $desc = await $self->describe_user_preference($user, $pref_name);
 
     my $possessive = $user == $event->from_user
                    ? 'Your'

--- a/lib/Synergy/Role/HasPreferences.pm
+++ b/lib/Synergy/Role/HasPreferences.pm
@@ -56,7 +56,7 @@ role {
       $Logger->log("couldn't get value for preference $pref_name: $@");
     }
 
-    return $pref_specs{$pref_name}->{describer}->( $val );
+    return await $pref_specs{$pref_name}->{describer}->($val);
   };
 
   method preference_help => sub ($self) {
@@ -73,9 +73,9 @@ role {
   #   help        => "This is a cool thing.\nIt's very great.",
   #   description => "a pref with a name",
   #   default     => value,
-  #   validator   => sub ($self, $val, $event) {},
-  #   describer   => sub ($val) {},
-  #   after_set   => sub ($self, $username, $value) {},
+  #   validator   => async sub ($self, $val, $event) {},
+  #   describer   => async sub ($val) {},
+  #   after_set   => async sub ($self, $username, $value) {},
   # }
   #
   # The validator sub will receive the raw text value from the user, and is
@@ -89,8 +89,8 @@ role {
 
     die "preference $name already exists in $class" if $pref_specs{$name};
 
-    $spec{describer} //= sub ($value) { return $value // '<undef>' };
-    $spec{after_set} //= sub ($self, $username, $value) {};
+    $spec{describer} //= async sub ($value) { return $value // '<undef>' };
+    $spec{after_set} //= async sub ($self, $username, $value) {};
 
     $pref_specs{$name} = \%spec;
   };
@@ -104,7 +104,7 @@ role {
     }
 
     my $spec = $pref_specs{ $pref_name };
-    my ($actual_value, $err) = $spec->{validator}->($self, $value, $event);
+    my ($actual_value, $err) = await $spec->{validator}->($self, $value, $event);
 
     my $full_name = $self->preference_namespace . q{.} . $pref_name;
 
@@ -164,7 +164,7 @@ role {
     $uprefs->{$pref_name} = $value;
     delete $uprefs->{$pref_name} unless defined $uprefs->{$pref_name};
 
-    $spec->{after_set}->($self, $username, $uprefs->{$pref_name});
+    await $spec->{after_set}->($self, $username, $uprefs->{$pref_name});
 
     $self->save_state;
 

--- a/lib/Synergy/UserDirectory.pm
+++ b/lib/Synergy/UserDirectory.pm
@@ -13,6 +13,8 @@ with (
 
 use experimental qw(signatures lexical_subs);
 use namespace::autoclean;
+
+use Future::AsyncAwait;
 use Path::Tiny;
 use Synergy::User;
 use Synergy::Util qw(known_alphabets read_config_file day_name_from_abbr);
@@ -273,7 +275,7 @@ __PACKAGE__->add_preference(
   name        => 'alphabet',
   help        => "Preferred alphabet (default: Latin): One of: $Alphabets",
   description => "Preferred alphabet for responses",
-  validator   => sub ($self, $value, @) {
+  validator   => async sub ($self, $value, @) {
     my ($known) = grep {; lc $_ eq lc $value } known_alphabets;
     return $known if $known;
     return (undef, "alphabet must be one of $Alphabets");
@@ -285,7 +287,7 @@ __PACKAGE__->add_preference(
   name        => 'phone',
   description => 'your phone number',
   help        => 'Your phone number, in the form +1NNNNNNNNNN',
-  validator   => sub ($self, $value, $event) {
+  validator   => async sub ($self, $value, $event) {
     # clear: allow undef, but no error
     return undef unless defined $value;
 
@@ -300,8 +302,8 @@ __PACKAGE__->add_preference(
 
 __PACKAGE__->add_preference(
   name => 'realname',
-  validator => sub { "$_[1]" },
-  after_set => sub ($self, $username, $value) {
+  validator => async sub { "$_[1]" },
+  after_set => async sub ($self, $username, $value) {
     $self->reload_user($username, { realname => $value });
   },
 );
@@ -311,7 +313,7 @@ __PACKAGE__->add_preference(
   help => 'one or more comma-separated aliases',
   description => "alternate names for a person",
   default => sub { [] },
-  validator => sub ($self, $value, $event) {
+  validator => async sub ($self, $value, $event) {
     my @names = map  {; lc $_    }
                 grep { length $_ }
                 split /\s*,\s*/, $value;
@@ -331,7 +333,7 @@ __PACKAGE__->add_preference(
 
     return \@names;
   },
-  describer => sub ($value) {
+  describer => async sub ($value) {
     return '<undef>' unless $value;
     return '<undef>' unless @$value;
     return join(q{, }, @$value);
@@ -342,7 +344,7 @@ __PACKAGE__->add_preference(
   name => 'pronoun',
   help => q{This is the pronoun you'd prefer to be used for you.},
   description => 'preferred personal pronoun (nominative case)',
-  validator => sub ($self, $value, @) {
+  validator => async sub ($self, $value, @) {
     my %valid_pronouns = map { $_ => 1 } qw(he she they);
 
     $value =~ s/\s*//g;
@@ -360,7 +362,7 @@ __PACKAGE__->add_preference(
 
 __PACKAGE__->add_preference(
   name => 'time-zone',
-  validator => sub ($self, $value, @) {
+  validator => async sub ($self, $value, @) {
     my $err = qq{"$value" doesn't look like a valid time zone name};
 
     eval { DateTime->now(time_zone => $value) };
@@ -376,8 +378,8 @@ __PACKAGE__->add_preference(
 __PACKAGE__->add_preference(
   name => 'business-hours',
   help      => q{when you work; you can use "weekdays, 09:00-17:00" or "Mon: 09:00-17:00, Tue: 10:00-12:00, (etc.)"},
-  describer => \&Synergy::Util::describe_business_hours,
-  validator => sub ($self, $value, @) {
+  describer => async sub ($value) { Synergy::Util::describe_business_hours($value) },
+  validator => async sub ($self, $value, @) {
     return Synergy::Util::validate_business_hours($value);
   },
 );
@@ -386,11 +388,11 @@ __PACKAGE__->add_preference(
   name => 'wfh-days',
   help      => q{days you work regularly from home; use "Wed, Fri" (etc.)"},
   default   => sub { [] },
-  describer => sub ($value) {
+  describer => async sub ($value) {
     my @all = map {; day_name_from_abbr($_) } @$value;
     return @all ? WORDLIST(@all) : '<none>';
   },
-  validator => sub ($self, $value, @) {
+  validator => async sub ($self, $value, @) {
     my @known = qw(mon tue wed thu fri sat sun);
     my %is_valid = map {; $_ => 1 } @known;
 

--- a/lib/Synergy/UserDirectory.pm
+++ b/lib/Synergy/UserDirectory.pm
@@ -333,7 +333,7 @@ __PACKAGE__->add_preference(
 
     return \@names;
   },
-  describer => async sub ($value) {
+  describer => async sub ($self, $value) {
     return '<undef>' unless $value;
     return '<undef>' unless @$value;
     return join(q{, }, @$value);
@@ -378,7 +378,7 @@ __PACKAGE__->add_preference(
 __PACKAGE__->add_preference(
   name => 'business-hours',
   help      => q{when you work; you can use "weekdays, 09:00-17:00" or "Mon: 09:00-17:00, Tue: 10:00-12:00, (etc.)"},
-  describer => async sub ($value) { Synergy::Util::describe_business_hours($value) },
+  describer => async sub ($self, $value) { Synergy::Util::describe_business_hours($value) },
   validator => async sub ($self, $value, @) {
     return Synergy::Util::validate_business_hours($value);
   },
@@ -388,7 +388,7 @@ __PACKAGE__->add_preference(
   name => 'wfh-days',
   help      => q{days you work regularly from home; use "Wed, Fri" (etc.)"},
   default   => sub { [] },
-  describer => async sub ($value) {
+  describer => async sub ($self, $value) {
     my @all = map {; day_name_from_abbr($_) } @$value;
     return @all ? WORDLIST(@all) : '<none>';
   },


### PR DESCRIPTION
The big goal here was "allow a preference describer to be async, so it can look up an opaque identifier in a remote API without locking up the whole bot".  To accomplish that, or as closely related work…

* the HasPreferences system uses async/await and made validator, describer, and after_set async
* the describer callback gets the reactor as first arg
* all reactors using those callbacks were updated to use the new semantics
* the Preferences reactor was updated to match, and to use CommandPost and async/await
* the PagerDuty reactor was updated to use CommandPost and async/await (see below)
* the Linear reactor was updated to use the Linear API to describe the default team setting

The PagerDuty reactor was pretty extensively updated.  It didn't need to be, strictly, but while doing this work, I found a few parts sort of tedious to update because of its extensive use of sequenced futures.  Since I knew there was at least one recent request for changes to this reactor, I thought that the change to async/await would be a good bit of work to throw on the pile, to make that request easier for someone to grant.