### PR TITLE
page reactor: add support to page oncall

### DIFF
--- a/lib/Synergy/Reactor/Page.pm
+++ b/lib/Synergy/Reactor/Page.pm
@@ -57,7 +57,12 @@ END
     my $pd = $self->hub->reactor_named('pagerduty');
 
     if ($pd) {
-      @to_page = map {; $pd->username_from_pd($_) } $pd->oncall_list->@*;
+      # Really, this should be able to use $pd->oncall_list, but that isn't set
+      # eagerly enough.  That should probably be made into a lazily cached
+      # attribute like we use for (for example) the Slack user list.  But we
+      # can do that in the future. -- rjbs, 2023-10-18
+      my @oncall_ids = await $pd->_current_oncall_ids;
+      @to_page = map {; $pd->username_from_pd($_) } @oncall_ids;
     } else {
       $Logger->log("Unable to find reactor 'pagerduty'") unless $pd;
     }

--- a/lib/Synergy/Reactor/Page.pm
+++ b/lib/Synergy/Reactor/Page.pm
@@ -62,7 +62,7 @@ END
       # attribute like we use for (for example) the Slack user list.  But we
       # can do that in the future. -- rjbs, 2023-10-18
       my @oncall_ids = await $pd->_current_oncall_ids;
-      @to_page = map {; $pd->username_from_pd($_) } @oncall_ids;
+      @to_page = grep {; $_ } map {; $pd->username_from_pd($_) } @oncall_ids;
     } else {
       $Logger->log("Unable to find reactor 'pagerduty'") unless $pd;
     }

--- a/t/page.t
+++ b/t/page.t
@@ -63,7 +63,7 @@ wait_for {
 is_deeply(
   [ $synergy->channel_named('test-1')->sent_messages ],
   [
-    { address => 'public', text => 'Page sent!' },
+    { address => 'public', text => 'Page sent to roxy!' },
   ],
   "sent a reply on the chat channel",
 );


### PR DESCRIPTION
The Page rector will then check with the PagerDuty reactor for who is oncall, then page the appropriate people