### PR TITLE
InABox: make the DO ssh key name configurable

### DIFF
--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -30,6 +30,12 @@ has ssh_key_id => (
   isa => 'Str',
 );
 
+has digitalocean_ssh_key_name => (
+  is  => 'ro',
+  isa => 'Str',
+  default => 'synergy',
+);
+
 has digitalocean_api_token => (
   is       => 'ro',
   isa      => 'Str',
@@ -659,7 +665,7 @@ async sub _get_ssh_key ($self) {
   my $dobby = $self->dobby;
   my $keys = await $dobby->json_get_pages_of("/account/keys", 'ssh_keys');
 
-  my ($ssh_key) = grep {; $_->{name} eq 'fminabox' } @$keys;
+  my ($ssh_key) = grep {; $_->{name} eq $self->digitalocean_ssh_key_name } @$keys;
 
   if ($ssh_key) {
     $Logger->log([ "Found SSH key: %s (%s)", $ssh_key->@{ qw(id name) } ]);


### PR DESCRIPTION
The 'fminabox' key is defunct.  I've added synergy's key as 'synergy' so it's clear where that key is.  And this makes it configurable so if we ever have a future fminabox where we don't purge cloud-init then it can be configurable