### PR TITLE
InABox: lowercase before parsing switches

### DIFF
--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -154,6 +154,7 @@ command box => {
     return await $event->error_reply("usage: box [status|create|destroy|shutdown|poweroff|poweron|vpn]");
   }
 
+  $args = lc($args) if $args;
   my ($switches, $error) = parse_switches($args);
   return await $event->error_reply("couldn't parse switches: $error") if $error;
 


### PR DESCRIPTION
It's common for me to use a phone to ask Synergy to spin up an Inabox, so by the time i'm at my desk it's ready to go.  My phone also likes to capitalise words.  And i'm a bit tired of stubbing my proverbial toe after `box create /version Bookworm` and being told there is no 'Bookworm' version available because of case sensitivity.

This seems like a reasonable local change to stop me bumping into this.