### PR TITLE
InABox: version and tags only lowercase

### DIFF
--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -191,6 +191,8 @@ sub _determine_version_and_tag ($self, $event, $switches) {
                      // $self->default_box_version;
 
   my ($version, $tag) = $switches->@{qw(version tag)};
+  $version = lc $version if $version;
+  $tag = lc $tag if $tag;
   my $is_default_box = !($version || $tag);
   $version //= $default_version;
   $tag //= $version;


### PR DESCRIPTION
It's common for me to use a phone to ask Synergy to spin up an Inabox, so by the time i'm at my desk it's ready to go.
My phone also likes to capitalise words.

I'm a bit tired of stubbing my proverbial toe after 'box create /version Bookworm' and being told there is no 'Bookworm' version available because of case sensitivity.