### PR TITLE
HTTPServer: specify IP address

### DIFF
--- a/lib/Synergy/Environment.pm
+++ b/lib/Synergy/Environment.pm
@@ -40,6 +40,12 @@ has server_port => (
   default => 8118,
 );
 
+has server_ip => (
+  is => 'ro',
+  isa => 'Str',
+  default => '0.0.0.0',
+);
+
 has metrics_path => (
   is => 'ro',
   isa => 'Str',

--- a/lib/Synergy/HTTPServer.pm
+++ b/lib/Synergy/HTTPServer.pm
@@ -39,6 +39,12 @@ has server_port => (
   required => 1,
 );
 
+has server_ip => (
+  is => 'ro',
+  isa => 'Str',
+  required => 1,
+);
+
 has tls_cert_file => (
   is => 'ro',
   isa => 'Str',
@@ -112,13 +118,14 @@ sub register_path ($self, $path, $app, $by) {
 async sub start ($self) {
   $self->loop->add($self->http_server);
 
-  $Logger->log([ "listening on port %s", $self->server_port ]);
+  $Logger->log([ "listening on ip:port %s:%s", $self->server_ip, $self->server_port ]);
 
   my %opts = (
     addr => {
       family => "inet",
       socktype => "stream",
       port => $self->server_port,
+      ip => $self->server_ip,
     },
     on_listen_error => sub { die "Cannot listen - $_[-1]\n" },
   );

--- a/lib/Synergy/Hub.pm
+++ b/lib/Synergy/Hub.pm
@@ -43,6 +43,7 @@ has env => (
   handles => [qw(
     name
     server_port
+    server_ip
     format_friendly_date
     user_directory
   )],
@@ -75,6 +76,7 @@ has server => (
   default => sub ($self) {
     my $s = Synergy::HTTPServer->new({
       name          => '_http_server',
+      server_ip     => $self->env->server_ip,
       server_port   => $self->env->server_port,
       tls_cert_file => $self->env->tls_cert_file,
       tls_key_file  => $self->env->tls_key_file,


### PR DESCRIPTION
Wasn't sure what ip address Synergy was listening on, then realised she was listening on everything.  Keep that default but allow specifying specific IPs