### PR TITLE
Page: Create a carbon copy of a page

### DIFF
--- a/lib/Synergy/Reactor/Page.pm
+++ b/lib/Synergy/Reactor/Page.pm
@@ -23,6 +23,12 @@ has page_channel_name => (
   required => 1,
 );
 
+has page_cc_channel_name => (
+  is => 'ro',
+  isa => 'Str',
+  default => 'slack',
+);
+
 has pushover_channel_name => (
   is => 'ro',
   isa => 'Str',
@@ -116,6 +122,15 @@ async sub _do_page($self, $event, $who, $what) {
     );
 
     $paged = 1;
+  }
+
+  if ($user->has_identity_for($self->page_cc_channel_name)) {
+    my $to_channel = $self->hub->channel_named($self->page_cc_channel_name);
+
+    my $from = $event->from_user ? $event->from_user->username
+                                 : $event->from_address;
+
+    $to_channel->send_message_to_user($user, "You are being paged by $from, who says: $what" );
   }
 
   if ($self->has_pushover_channel) {

--- a/t/page.t
+++ b/t/page.t
@@ -2,6 +2,10 @@
 use v5.32.0;
 use warnings;
 
+use experimental 'signatures';
+
+use lib 'lib';
+
 use Test::More;
 
 use Synergy::Logger::Test '$Logger';
@@ -16,59 +20,99 @@ use Synergy::Tester;
 
 my $PAGE = "Hello\n\nfriend.";
 
-my $synergy = Synergy::Tester->new_tester({
-  users => {
-    roxy => {
-      extra_identities => {
-        'test-1' => 'Rone',
-        'test-2' => 'Rtwo',
+my $tmpfile = Path::Tiny->tempfile;
+
+my sub new_synergy (%extra_page_reactor_args) {
+  # Initialize Synergy.
+  my $synergy = Synergy::Hub->synergize(
+    {
+      user_directory => "t/data/users-page.yaml",
+      channels => {
+        'test-1' => {
+          class     => 'Synergy::Channel::Test',
+          todo      => [
+            [ send    => { text => "synergy: page roxy: $PAGE" }  ],
+            [ wait    => { seconds => 0.1  }  ],
+          ],
+        },
+        'test-2' => {
+          class     => 'Synergy::Channel::Test',
+          prefix    => q{synergy},
+        },
+        'test-3' => {
+          class     => 'Synergy::Channel::Test',
+          prefix    => q{synergy},
+        }
       },
-    },
-    stormer => {
-      extra_identities => {
-        'test-1' => 'Mone',
-        'test-2' => 'Mtwo',
-      }
-    },
-  },
-  extra_channels => {
-    'test-2' => {
-      class     => 'Synergy::Channel::Test',
-      prefix    => q{synergy},
-    },
-    'test-3' => {
-      class     => 'Synergy::Channel::Test',
-      prefix    => q{synergy},
+      reactors => {
+        page => {
+          class => 'Synergy::Reactor::Page',
+          page_channel_name => 'test-2',
+          pushover_channel_name => 'test-3',
+          %extra_page_reactor_args,
+        },
+      },
+      state_dbfile => "$tmpfile",
+      server_port => empty_port(),
     }
-  },
-  reactors => {
-    page => {
-      class => 'Synergy::Reactor::Page',
-      page_channel_name => 'test-2',
-      pushover_channel_name => 'test-3',
-    },
-  },
-});
+  );
 
-my $result = $synergy->run_test_program([
-  [ send    => { text => "synergy: page roxy: $PAGE" }  ],
-  [ wait    => { seconds => 0.1  }  ],
-]);
+  return $synergy;
+}
 
-is_deeply(
-  [ $synergy->channel_named('test-channel')->sent_messages ],
-  [
-    { address => 'public', text => 'Page sent to roxy!' },
-  ],
-  "sent a reply on the chat channel",
-);
+subtest "test without page-cc channel" => sub {
+  my $synergy = new_synergy();
 
-is_deeply(
-  [ $synergy->channel_named('test-2')->sent_messages ],
-  [
-    { address => 'Rtwo', text => "tester says: $PAGE" },
-  ],
-  "sent a page on the page channel",
-);
+  # Tests begin here.
+  testing_loop($synergy->loop);
+
+  wait_for {
+    $synergy->channel_named('test-1')->is_exhausted;
+  };
+
+  is_deeply(
+    [ $synergy->channel_named('test-1')->sent_messages ],
+    [
+      { address => 'public', text => 'Page sent to roxy!' },
+    ],
+    "sent a reply on the chat channel",
+  );
+
+  is_deeply(
+    [ $synergy->channel_named('test-2')->sent_messages ],
+    [
+      { address => 'Rtwo', text => "tester says: $PAGE" },
+    ],
+    "sent a page on the page channel",
+  );
+};
+
+subtest "test with page-cc channel" => sub {
+  my $synergy = new_synergy(page_cc_channel_name => 'test-1');
+
+  # Tests begin here.
+  testing_loop($synergy->loop);
+
+  wait_for {
+    $synergy->channel_named('test-1')->is_exhausted;
+  };
+
+  is_deeply(
+    [ $synergy->channel_named('test-1')->sent_messages ],
+    [
+      { address => 'Rone',   text => "You are being paged by tester, who says: $PAGE" },
+      { address => 'public', text => 'Page sent to roxy!' },
+    ],
+    "sent a reply on the chat channel",
+  );
+
+  is_deeply(
+    [ $synergy->channel_named('test-2')->sent_messages ],
+    [
+      { address => 'Rtwo', text => "tester says: $PAGE" },
+    ],
+    "sent a page on the page channel",
+  );
+};
 
 done_testing;


### PR DESCRIPTION
Synergy pages can use an ephemeral channel such as a voice call.

This change allows to configure a secondary channel that is intended to be a permanent reference copy for the recipient.