### PR TITLE
Transliterate: improve error message, add a test

### DIFF
--- a/lib/Synergy/Reactor/Transliterate.pm
+++ b/lib/Synergy/Reactor/Transliterate.pm
@@ -17,8 +17,11 @@ command transliterate => {
 } => async sub ($self, $event, $rest) {
   my ($alphabet, $text) = $rest =~ /\Ato (\S+): (.+)\z/i;
 
-  return await $event->error_reply("Sorry, I don't know that alphabet.")
-    unless defined $alphabet;
+  unless (defined $alphabet) {
+    return await $event->error_reply(
+      "Sorry, I didn't understand that.  It's: *transliterate to `SCRIPT`: `MESSAGE`*"
+    );
+  }
 
   return await $event->error_reply("Sorry, I don't know that alphabet.")
     unless grep {; lc $_ eq lc $alphabet } known_alphabets;

--- a/lib/Synergy/UserDirectory.pm
+++ b/lib/Synergy/UserDirectory.pm
@@ -280,7 +280,7 @@ __PACKAGE__->add_preference(
     return $known if $known;
     return (undef, "alphabet must be one of $Alphabets");
   },
-  default     => 'English',
+  default     => 'Latin',
 );
 
 __PACKAGE__->add_preference(

--- a/t/transliterate.t
+++ b/t/transliterate.t
@@ -1,0 +1,44 @@
+#!perl
+use v5.32.0;
+use warnings;
+use experimental 'signatures';
+
+use utf8;
+
+use Test::More;
+
+use IO::Async::Test;
+use Synergy::Tester;
+
+my $synergy = Synergy::Tester->new_tester({
+  reactors => {
+    echo => { class => 'Synergy::Reactor::Transliterate' },
+  },
+  default_from => 'alice',
+  users => {
+    alice   => undef,
+    charlie => undef,
+  },
+});
+
+my $result = $synergy->run_test_program([
+  [ send  => { text => "synergy: transliterate to Futhark: Hello world." }  ],
+  [ wait  => { seconds => 0.1  }  ],
+  [ send  => { text => "synergy: transliterate into italic: This will fail" } ],
+]);
+
+my @sent = $synergy->channel_named('test-channel')->sent_messages;
+
+is(@sent, 2, "two replies recorded");
+
+is(  $sent[0]{address}, 'public',         "1st: expected address");
+like($sent[0]{text},    qr{ᚺᛖᛚᛚᛟ ᚹᛟᚱᛚᛞ.}, "1st: expected text");
+
+is(  $sent[1]{address}, 'public',         "1st: expected address");
+like(
+  $sent[1]{text},
+  qr{didn't understand that}, # as opposed to "unknown alphabet"
+  "2nd: expected text",
+);
+
+done_testing;


### PR DESCRIPTION
1.  fix the default user.alphabet to Latin ("English" was harmless but wrong)
2.  on bogus use of "transliterate" provide the right usage, rather than claiming that it is an unknown alphabet
3.  tests!!