### PR TITLE
TimeClock: avoid blocking and dying (those are bad)

### DIFF
--- a/lib/Synergy/Reactor/TimeClock.pm
+++ b/lib/Synergy/Reactor/TimeClock.pm
@@ -432,16 +432,29 @@ sub check_for_shift_changes ($self) {
 
       next unless $will_send;
 
+      $Logger->log([ "kicking off %s report for %s", $which, $user->username ]);
       my $report = $report_reactor->begin_report($report{$which}, $user);
 
-      my ($text, $alts) = $report->get;
+      $report
+        ->else(sub (@error) {
+          $Logger->log([
+            "ERROR sending %s report to %s: %s",
+            $which,
+            $user->username,
+            "@error",
+          ]);
+          Future->done;
+        })
+        ->then(sub ($text, $alts) {
+          return Future->done unless defined $text; # !? -- rjbs, 2019-10-29
 
-      next unless defined $text; # !? -- rjbs, 2019-10-29
+          $Logger->log([ "sending %s report for %s", $which, $user->username ]);
+          $channel->send_message_to_user($user, $text, $alts);
 
-      $Logger->log([ "sending %s report for %s", $which, $user->username ]);
-      $channel->send_message_to_user($user, $text, $alts);
-
-      $self->set_last_report_time_for($user->username, $now);
+          $self->set_last_report_time_for($user->username, $now);
+          return Future->done;
+        })
+        ->retain;
 
       next USER;
     }

--- a/lib/Synergy/Reactor/TimeClock.pm
+++ b/lib/Synergy/Reactor/TimeClock.pm
@@ -446,7 +446,18 @@ sub check_for_shift_changes ($self) {
           Future->done;
         })
         ->then(sub ($text, $alts) {
-          return Future->done unless defined $text; # !? -- rjbs, 2019-10-29
+          unless (defined $text) {
+            # I don't know anymore whether this is odd.  Rather than audit, I'm
+            # going to add this log line and then either drop it when I realize
+            # it happens all the time on purpose *or* fix things where it shows
+            # up. -- rjbs, 2024-04-19
+            $Logger->log([
+              "no text returned by %s report for %s",
+              $which,
+              $user->username,
+            ]);
+            return Future->done;
+          }
 
           $Logger->log([ "sending %s report for %s", $which, $user->username ]);
           $channel->send_message_to_user($user, $text, $alts);


### PR DESCRIPTION
The old code has this:

    my $report = $report_reactor->begin_report($report{$which}, $user);

    my ($text, $alts) = $report->get;

    next unless defined $text; # !? -- rjbs, 2019-10-29

    $Logger->log([ "sending %s report for %s", $which, $user->username ]);
    $channel->send_message_to_user($user, $text, $alts);

That ->get means the whole `check_for_shift_changes` method, called by an every-15m timer, would block.  Worse, it would convert any failed future into an exception, and because `check_for_shift_changes` isn't called from a reaction, it isn't handled by the hub's usual exception handler.

This fix is fairly crude, but it should avoid blocking and crashing. Future work should...

* convert this stuff to async/await!
* add an uptime gauge to the Prometheus endpoint
* improve how we log errors especially