### PR TITLE
GitLab: Fix post_gitlab_snippet headers

### DIFF
--- a/lib/Synergy/Reactor/GitLab.pm
+++ b/lib/Synergy/Reactor/GitLab.pm
@@ -1064,10 +1064,7 @@ async sub mr_report ($self, $who, $arg = {}) {
 async sub post_gitlab_snippet ($self, $payload) {
   my $res = await $self->hub->http_post(
     $self->api_uri . '/v4/snippets',
-    headers => {
-      'PRIVATE-TOKEN' => $self->api_token,
-    },
-
+    'PRIVATE-TOKEN' => $self->api_token,
     Content_Type => 'application/json',
     Content      => encode_json($payload),
   );


### PR DESCRIPTION
This has been broken since 98df89e when it was changed to use `hub->http_post`

Other than `Content` and `Content_Type` k:v pairs, `hub->http_request()` presumes all other k:v pairs are headers.

By calling with with headers => { foo=> bar }, the actual arguments into http_client->do_request() were

headers => { headers => { foo => bar } }
instead of
headers => { foo => bar }