### PR TITLE
InABox: box vpn omit tag in hostname by default

### DIFF
--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -629,7 +629,7 @@ sub handle_poweron ($self, $event, $switches) {
 }
 
 sub handle_vpn ($self, $event, $switches) {
-  my ($version, $tag) = $self->_determine_version_and_tag($event, $switches);
+  my ($version, $tag, $is_default_box) = $self->_determine_version_and_tag($event, $switches);
 
   my $template = Text::Template->new(
     TYPE       => 'FILE',
@@ -638,7 +638,7 @@ sub handle_vpn ($self, $event, $switches) {
   );
 
   my $config = $template->fill_in(HASH => {
-    droplet_host => $self->_box_name_for($event->from_user, $tag),
+    droplet_host => $self->_box_name_for($event->from_user, ($is_default_box ? () : $tag)),
   });
 
   $event->from_channel->send_file_to_user($event->from_user, 'fminabox.conf', $config);


### PR DESCRIPTION
Currently when generating vpn config we are always including the tag in the fqdn generated. eg 'user-bullsye.boxdomain.com'

This is fine until we bump the default version from bullseye -> bookworm and people get understandably confused when their vpn doens't work any more.

On 'box create' without a /version or /tag passed in we setup dns for both the 'user-tag.boxdomain.com' and 'user.boxdomain.com' (the latter was the only thing we had before we added multiple box support).

So lets rely on the dns entry omitting the tag by default when invoking 'box vpn' without a /version or /tag switch