### PR TITLE
Slack: rewrite send_file using new Slack APIs

### DIFF
--- a/lib/Synergy/Channel/Slack.pm
+++ b/lib/Synergy/Channel/Slack.pm
@@ -456,9 +456,9 @@ sub maybe_delete_reply ($self, $slack_event) {
   $self->delete_reply($orig_ts, $_) for @error_ts;
 }
 
-sub send_file_to_user ($self, $user, $filename, $content) {
+async sub send_file_to_user ($self, $user, $filename, $content) {
   my $where = $self->slack->dm_channel_for_user($user, $self);
-  return $self->slack->send_file($where, $filename, $content);
+  return await $self->slack->send_file($where, $filename, $content);
 }
 
 sub _uri_from_event ($self, $event) {

--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -628,7 +628,7 @@ sub handle_poweron ($self, $event, $switches) {
   return $self->_handle_power($event, 'on', $tag);
 }
 
-sub handle_vpn ($self, $event, $switches) {
+async sub handle_vpn ($self, $event, $switches) {
   my ($version, $tag, $is_default_box) = $self->_determine_version_and_tag($event, $switches);
 
   my $template = Text::Template->new(
@@ -641,9 +641,9 @@ sub handle_vpn ($self, $event, $switches) {
     droplet_host => $self->_box_name_for($event->from_user, ($is_default_box ? () : $tag)),
   });
 
-  $event->from_channel->send_file_to_user($event->from_user, 'fminabox.conf', $config);
+  await $event->from_channel->send_file_to_user($event->from_user, 'fminabox.conf', $config);
 
-  $event->reply("I sent you a VPN config in a direct message. Download it and import it into your OpenVPN client.");
+  await $event->reply("I sent you a VPN config in a direct message. Download it and import it into your OpenVPN client.");
 }
 
 async sub _get_droplet_for ($self, $user, $tag = undef) {

--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -487,16 +487,8 @@ async sub _setup_droplet ($self, $event, $droplet, $key_file, $args = []) {
   if ($event->from_channel->isa('Synergy::Channel::Slack')) {
     $message .= " Here's the output from setup:";
 
-    return await $event->from_channel->slack->api_call(
-      'files.upload',
-      {
-        form_encoded => 1, # Sigh.
-
-        content => "$stderr\n----(stdout)----\n$stdout",
-        channels => $event->conversation_address,
-        initial_comment => $message,
-      },
-    );
+    my $content = "$stderr\n----(stdout)----\n$stdout";
+    await $event->from_channel->slack->send_file($event->conversation_address, 'setup.log', $content);
   } else {
     $Logger->log("we ran ssh, but not via Slack, so stdout/stderr discarded");
   }

--- a/lib/Synergy/Reactor/SlackID.pm
+++ b/lib/Synergy/Reactor/SlackID.pm
@@ -89,16 +89,8 @@ command slacksnippet => {
 
   my $text = join q{}, ("$text\n") x 25;
 
-  my $res = await $channel->slack->api_call(
-    'files.upload',
-    {
-      form_encoded => 1, # Sigh.
-
-      content => $text,
-      channels => $event->conversation_address,
-      initial_comment => "Here's what you said, as a snippet.",
-    },
-  );
+  await $channel->slack->send_file($event->conversation_address, 'snippet', $text);
+  $event->reply("Here's what you said, as a snippet.");
 
   return;
 };


### PR DESCRIPTION
files.upload is deprecated, use new method of files.getUploadURLExternal then files.completeUploadExternal