### PR TITLE
Preferences: No backticks in console

### DIFF
--- a/lib/Synergy/Reactor/Preferences.pm
+++ b/lib/Synergy/Reactor/Preferences.pm
@@ -146,7 +146,8 @@ responder dump => {
   my $prefs = join "\n", @pref_strings;
   my $name = $for_user->username;
 
-  return await $event->reply("Preferences for $name: ```$prefs```");
+  $prefs = "```$prefs```" unless $event->from_channel->isa('Synergy::Channel::Console');
+  return await $event->reply("Preferences for $name:\n$prefs");
 };
 
 async sub _set_pref ($self, $event, $who, $full_name, $pref_value) {


### PR DESCRIPTION
Backticks are great in Slack and presumably Discord.  Look very out of place in the console.

Before:
```
│ Preferences for adavis: ```clox.include-aelt: 0
│ gitlab.user-id: <undef>
```

After
```
│ Preferences for adavis:
│ clox.include-aelt: 0
│ gitlab.user-id: <undef>
```

