### PR TITLE
Reactor/Linear: Implement 'triage /all'

### DIFF
--- a/lib/Synergy/Reactor/Linear.pm
+++ b/lib/Synergy/Reactor/Linear.pm
@@ -712,14 +712,31 @@ command triage => {
     *triage `[TEAM]`*: list unassigned issues in the Triage state
 
     This lists (the first page of) all unassigned issues in the Triage state in
-    Linear.  You can supply an argument, the name of a team, to see only issues
-    for that team.
+    Linear.
+    You can supply an argument, the name of a team, to see only issues for that
+    team.
+    You can supply a switch, /all, to also see assigned issues.
     EOH
-} => async sub ($self, $event, $team_name) {
+} => async sub ($self, $event, $text) {
   await $self->_with_linear_client($event, async sub ($linear) {
     my %extra_search;
 
-    if (length $team_name) {
+    # I've implemented half of a getopt parser here... sorry
+    my $opt_all = 0;
+    my @args;
+
+    my @words = split ' ', $text if length $text;
+
+    for my $arg (@words) {
+      if ($arg eq '/all') {
+        $opt_all = 1;
+      } else {
+        push @args, $arg;
+      }
+    }
+
+    if (length $args[0]) {
+      my $team_name = $args[0];
       my $team = await $linear->lookup_team($team_name);
 
       unless ($team) {
@@ -729,12 +746,15 @@ command triage => {
       %extra_search = (team => $team->{id});
     }
 
+    if (!$opt_all) {
+      $extra_search{assignee} = undef;
+    }
+
     return await $self->_handle_search(
       $event,
       {
         search => {
           state    => 'Triage',
-          assignee => undef,
           %extra_search,
         },
         zero   => "No unassigned issues in triage!  Great!",

--- a/lib/Synergy/Reactor/Linear.pm
+++ b/lib/Synergy/Reactor/Linear.pm
@@ -725,14 +725,21 @@ command triage => {
     my $opt_all = 0;
     my @args;
 
-    my @words = split ' ', $text if length $text;
+    my @words = length $text ? (split /\s+/, $text) : ();
 
     for my $arg (@words) {
       if ($arg eq '/all') {
         $opt_all = 1;
+      } elsif ($arg =~ /^\//) {
+        Synergy::X->throw_public("triage: Unrecognized switch: $arg");
       } else {
         push @args, $arg;
       }
+    }
+
+    if (@args > 1) {
+      my $all_args = join ' ', @args;
+      Synergy::X->throw_public("triage: too many args - please only pass a single arg for the team name (I got: $all_args)");
     }
 
     if (length $args[0]) {


### PR DESCRIPTION
The 'triage' command by default shows only unassigned issues, in order to assist with triaging tickets created or moved from other teams.

However, tickets we (in PLAT) create for triage through `synergy ++` will have the creator assigned. This is fine but we want to be able to query synergy for these tickets, so we do that with `synergy triage plat /all`.

Ticket: PLAT-2422