### PR TITLE
InABox: sort snapshots exclusively by created_at time

### DIFF
--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -709,8 +709,7 @@ async sub _get_snapshot ($self, $version) {
   my $dobby = $self->dobby;
   my $snaps = await $dobby->json_get_pages_of('/snapshots', 'snapshots');
 
-  my ($snapshot) = sort { $b->{name} cmp $a->{name}
-                       || $b->{created_at} cmp $a->{created_at} }
+  my ($snapshot) = sort { $b->{created_at} cmp $a->{created_at} }
                    grep { $_->{name} =~ m/^fminabox-\Q$version\E/ }
                    @$snaps;
 


### PR DESCRIPTION
Had a minor bug where the wrong snapshot was spun up because it matched `fminabox-$version` but had additional stuff afterwards that sorted earlier

This isn't a fix the issue it's possible to create non main builds that collide in snapshot name, but at least they'll time out being the snapshot synergy grabs in <24 hours