### PR TITLE
Reactor/Page: Implement "page oncall /all"

### DIFF
--- a/lib/Synergy/Reactor/Page.pm
+++ b/lib/Synergy/Reactor/Page.pm
@@ -57,7 +57,6 @@ Special On-Call paging:
 • *page /all oncall: `MESSAGE`*: send this message to all oncall engineers
 END
 } => async sub ($self, $event, $rest) {
-  #my ($who, $what) = $event->text =~ m/^page\s+@?([a-z]+):?\s+(.*)/is;
   # I've implemented half of a getopt parser here... sorry
   my $opt_all = 0;
   my @args;
@@ -80,8 +79,9 @@ END
     return await $event->error_reply("usage: page USER: MESSAGE");
   }
 
-  my $who = $args[0] =~ s/:$//r;
-  my $what = join ' ', @args[1 .. $#args];
+  my $who = shift @args;
+  $who = ($who =~ s/:$//r);
+  my $what = join ' ', @args;
 
   my @to_page;
   if ($who eq 'oncall') {
@@ -92,12 +92,9 @@ END
       # eagerly enough.  That should probably be made into a lazily cached
       # attribute like we use for (for example) the Slack user list.  But we
       # can do that in the future. -- rjbs, 2023-10-18
-      my @oncall_ids;
-      if ($opt_all) {
-        @oncall_ids = await $pd->_escalation_oncalls;
-      } else {
-        @oncall_ids = await $pd->_current_oncall_ids;
-      }
+      my @oncall_ids = $opt_all
+        ? await $pd->_escalation_oncall_ids
+        : await $pd->_current_oncall_ids;
       @to_page = grep {; $_ } map {; $pd->username_from_pd($_) } @oncall_ids;
     } else {
       $Logger->log("Unable to find reactor 'pagerduty'") unless $pd;

--- a/lib/Synergy/Reactor/PagerDuty.pm
+++ b/lib/Synergy/Reactor/PagerDuty.pm
@@ -739,7 +739,7 @@ sub _current_oncall_ids ($self) {
 
 # returns all the oncall users on the final escalation rule
 # used for "page all oncall engineers"
-sub _escalation_oncalls ($self) {
+sub _escalation_oncall_ids ($self) {
   my $policy_id = $self->escalation_policy_id;
 
   return $self->_pd_request(GET => '/escalation_policies/' . $policy_id)

--- a/lib/Synergy/Reactor/PagerDuty.pm
+++ b/lib/Synergy/Reactor/PagerDuty.pm
@@ -737,6 +737,23 @@ sub _current_oncall_ids ($self) {
   });
 }
 
+# returns all the oncall users on the final escalation rule
+# used for "page all oncall engineers"
+sub _escalation_oncalls ($self) {
+  my $policy_id = $self->escalation_policy_id;
+
+  return $self->_pd_request(GET => '/escalation_policies/' . $policy_id)
+    ->then(sub ($data){
+      my $final_escalation_rule = $data->{escalation_policy}{escalation_rules}[-1];
+
+      my @oncalls = map {; $_->{id} }
+                    grep {; $_->{type} eq 'user_reference' }
+                    $final_escalation_rule->{targets}->@*;
+
+      return Future->done(@oncalls);
+      });
+}
+
 # This returns a Future that, when done, gives a boolean as to whether or not
 # $who is oncall right now.
 sub _user_is_oncall ($self, $who) {


### PR DESCRIPTION
"page oncall /all" will page everyone in the final oncall escalation, as a last resort emergency flare.

This requires redoing the argument parsing in the page command, and implementing a function in the PagerDuty module to determine all the users in the oncall escalation.