### PR TITLE
tests: make them work without all required modules

### DIFF
--- a/t/01-compile.t
+++ b/t/01-compile.t
@@ -11,9 +11,11 @@ my @files = `find lib -type f -name '*.pm'`;
 chomp @files;
 
 my %only_if = (
+  'Synergy::Reactor::InABox'              => [ 'Dobby::Client' ],
   'Synergy::Reactor::Linear'              => [ 'Linear::Client' ],
   'Synergy::Reactor::LinearNotification'  => [ 'Linear::Client' ],
   'Synergy::Reactor::RememberTheMilk'     => [ 'WebService::RTM::CamelMilk' ],
+  'Synergy::Reactor::Roll'                => [ 'Games::Dice' ],
   'Synergy::Reactor::Zendesk'             => [ 'Zendesk::Client' ],
 );
 

--- a/t/inabox.t
+++ b/t/inabox.t
@@ -6,11 +6,19 @@ use lib 't/lib';
 use Future;
 use IO::Async::Test;
 use JSON::MaybeXS qw(encode_json);
+use Module::Runtime qw(require_module);
 use Plack::Response;
 use Sub::Override;
 use Storable qw(dclone);
 use Test::More;
 use Test::Deep;
+
+BEGIN {
+  my $has_dobby_client = eval { require_module('Dobby::Client') } ? 1 : 0;
+  unless ($has_dobby_client) {
+    plan skip_all => "test requires Dobby::Client";
+  }
+}
 
 use Synergy::Logger::Test '$Logger';
 use Synergy::Reactor::InABox;


### PR DESCRIPTION
I got nerdsniped into looking at this code again, and wanted to run the tests, which failed because I don't have all the suggested modules. This does two things:

- Fix t/01-compile.t by adding a few more optional modules to the existing list of skips
- Skip all of t/inabox.t if Dobby::Client is not installed.