### PR TITLE
Synergy::BoxManager: inabox management outside the hub

### DIFF
--- a/lib/Synergy/BoxManager.pm
+++ b/lib/Synergy/BoxManager.pm
@@ -1,0 +1,482 @@
+package Synergy::BoxManager;
+use Moose;
+
+use v5.36.0;
+
+use Carp ();
+use Dobby::Client;
+use Future::AsyncAwait;
+use Path::Tiny;
+use Process::Status;
+
+has dobby => (
+  is => 'ro',
+  required => 1,
+);
+
+# This is not here so we can set it to zero and get rate limited or see bugs in
+# production.  It's here so we can make the tests run fast. -- rjbs, 2024-02-09
+has post_creation_delay => (
+  is => 'ro',
+  default => 5,
+);
+
+has box_domain => (
+  is       => 'ro',
+  isa      => 'Str',
+  required => 1,
+);
+
+# error   - report to the user and stop processing
+# message - report to the user and continue
+# log     - write to syslog, continue; args may be String::Flogger-ed
+# snippet - post a snippet and return its URL
+for my $type (qw( error log message snippet )) {
+  has "$type\_cb" => (
+    is  => 'ro',
+    isa => 'CodeRef',
+    required => 1,
+    traits   => [ 'Code' ],
+    handles  => {
+      "handle_$type" => 'execute',
+    },
+  );
+}
+
+after "handle_error" => sub ($self, $error_str, @) {
+  # The error_cb should always die, meaning this should never be reached.  If
+  # it is, it means somebody wrote an error_cb that doesn't die, so it is our
+  # job to die on their behalf.  Like in that movie Infinity Pool.
+  die "error_cb did not throw an error for: $error_str";
+};
+
+package Synergy::BoxManager::ProvisionRequest {
+  use Moose;
+
+  has region      => (is => 'ro', isa => 'Str',     required => 1);
+  has size        => (is => 'ro', isa => 'Str',     required => 1);
+  has username    => (is => 'ro', isa => 'Str',     required => 1);
+  has version     => (is => 'ro', isa => 'Str',     required => 1);
+
+  has tag         => (is => 'ro', isa => 'Maybe[Str]');
+  has project_id  => (is => 'ro', isa => 'Maybe[Str]');
+
+  has is_default_box   => (is => 'ro', isa => 'Bool', default => 0);
+  has run_custom_setup => (is => 'ro', isa => 'Bool', default => 0);
+  has setup_switches   => (is => 'ro', isa => 'Maybe[ArrayRef]');
+
+  has ssh_key_id => (is  => 'ro', isa => 'Str', required => 1);
+  has digitalocean_ssh_key_name => (is  => 'ro', isa => 'Str', default => 'synergy');
+
+  no Moose;
+  __PACKAGE__->meta->make_immutable;
+}
+
+async sub create_droplet ($self, $spec) {
+  my $maybe_droplet = await $self->_get_droplet_for($spec->username, $spec->tag);
+
+  if ($maybe_droplet) {
+    $self->handle_error(
+      "This box already exists: " . $self->_format_droplet($maybe_droplet)
+    );
+  }
+
+  my $name = $self->box_name_for($spec->username, $spec->tag);
+
+  my $region = $spec->region;
+  $self->handle_message("Creating $name in $region, this will take a minute or two.");
+
+  # It would be nice to do these in parallel, but in testing that causes
+  # *super* strange errors deep down in IO::Async if one of the calls fails and
+  # the other does not, so here we'll just admit defeat and do them in
+  # sequence. -- michael, 2020-04-02
+  my $snapshot = await $self->get_snapshot_for_version($spec->version);
+  my %snapshot_regions = map {; $_ => 1 } $snapshot->{regions}->@*;
+
+  unless ($snapshot_regions{$region}) {
+    $self->handle_error("I'm unable to create an fminabox in the region '$region'.");
+  }
+
+  my $key_file = $self->_get_my_ssh_key_file($spec);
+  my $ssh_key  = await $self->_get_ssh_key($spec);
+
+  my %droplet_create_args = (
+    name     => $name,
+    region   => $spec->region,
+    size     => $spec->size,
+    image    => $snapshot->{id},
+    ssh_keys => [ $ssh_key->{id} ],
+    tags     => [ 'fminabox', "owner:" . $spec->username ],
+  );
+
+  $self->handle_log([ "Creating droplet: %s", \%droplet_create_args ]);
+
+  my $droplet = await $self->dobby->create_droplet(\%droplet_create_args);
+
+  unless ($droplet) {
+    $self->handle_error("There was an error creating the box. Try again.");
+  }
+
+  # We delay this because a completed droplet sometimes does not show up in GET
+  # /droplets immediately, which causes annoying problems.  Waiting 5s is a
+  # silly fix, but seems to work, and it's not like box creation is
+  # lightning-fast anyway. -- michael, 2021-04-16
+  await $self->dobby->loop->delay_future(after => $self->post_creation_delay);
+
+  $droplet = await $self->_get_droplet_for($spec->username, $spec->tag);
+
+  if ($droplet) {
+    $self->handle_log([ "Created droplet: %s (%s)", $droplet->{id}, $droplet->{name} ]);
+  } else {
+    # We don't fail here, because we want to try to update DNS regardless.
+    $self->handle_message(
+      "Box was created, but now I can't find it! Check the DigitalOcean console and maybe try again."
+    );
+  }
+
+  # Add it to the relevant project. If this fails, then...oh well.
+  # -- ?
+  if ($spec->project_id) {
+    await $self->dobby->add_droplet_to_project(
+      $droplet->{id},
+      $spec->project_id
+    );
+  }
+
+  # update the DNS name. we will assume this succeeds; if it fails the box
+  # is still good and there's not really much else we can do.
+  my $ip_address = $self->_ip_address_for_droplet($droplet);
+
+  my $is_default_box = $spec->is_default_box;
+
+  my @names = (
+    $self->_dns_name_for($spec->username, $spec->tag),
+    ($is_default_box ? $self->_dns_name_for($spec->username) : ())
+  );
+
+  for my $name (@names) {
+    $self->handle_log("updating DNS names for $name");
+
+    await $self->dobby->point_domain_record_at_ip(
+      $self->box_domain,
+      $name,
+      $ip_address,
+    );
+  }
+
+  $self->handle_message(
+    "Box created, will now run setup. Your box is: "
+    . $self->_format_droplet($droplet)
+  );
+
+  return await $self->_setup_droplet(
+    $spec,
+    $droplet,
+    $key_file,
+  );
+}
+
+sub _get_my_ssh_key_file ($self, $spec) {
+  my $key_file = $spec->ssh_key_id
+               ? path($spec->ssh_key_id)->absolute("$ENV{HOME}/.ssh/")
+               : undef;
+
+  unless ($key_file && -r $key_file) {
+    $self->handle_log(["Cannot read SSH key for inabox setup (from %s)", $spec->ssh_key_id]);
+    $self->handle_error(
+      "No SSH credentials for running box setup. This is a problem - aborting."
+    );
+  }
+
+  return $key_file;
+}
+
+async sub _setup_droplet ($self, $spec, $droplet, $key_file) {
+  my $ip_address = $self->_ip_address_for_droplet($droplet);
+
+  my $args = $spec->setup_switches // [];
+  unless ($self->_validate_setup_args($args)) {
+    $self->handle_message("Your /setup arguments don't meet my strict and undocumented requirements, sorry.  I'll act like you provided none.");
+    $args = [];
+  }
+
+  my $success;
+  my $max_tries = 20;
+  TRY: for my $try (1..$max_tries) {
+    my $socket;
+    eval {
+      $socket = await $self->dobby->loop->connect(addr => {
+        family   => 'inet',
+        socktype => 'stream',
+        port     => 22,
+        ip       => $ip_address,
+      });
+    };
+
+    if ($socket) {
+      # We didn't need the connection, just to know it worked!
+      undef $socket;
+
+      $self->handle_log([
+        "ssh on %s is up, will now move on to running setup",
+        $ip_address,
+      ]);
+
+      $success = 1;
+
+      last TRY;
+    }
+
+    my $error = $@;
+    if ($error !~ /Connection refused/) {
+      $self->handle_log([
+        "weird error connecting to %s:22: %s",
+        $ip_address,
+        $error,
+      ]);
+    }
+
+    $self->handle_log([
+      "ssh on %s is not up, maybe wait and try again; %s tries remain",
+      $ip_address,
+      $max_tries - $try,
+    ]);
+
+    await $self->dobby->loop->delay_future(after => 1);
+  }
+
+  unless ($success) {
+    # Really, this is an error, but when called in Synergy, we wouldn't want
+    # the user to be able to edit the "box create" message and try again.  The
+    # Droplet was created, but now it's weirdly inaccessible.
+    $self->handle_message("I couldn't connect to your box to set it up. A human will need to clean this up!");
+    return;
+  }
+
+  my @setup_args = $spec->run_custom_setup ? () : ('--no-custom');
+
+  my @ssh_command = (
+    "ssh",
+      '-A',
+      '-i', "$key_file",
+      '-l', 'root',
+      '-o', 'UserKnownHostsFile=/dev/null',
+      '-o', 'StrictHostKeyChecking=no',
+
+    $ip_address,
+    (
+      qw( fmdev mysetup ),
+      '--user', $spec->username,
+      @setup_args,
+      '--',
+      @$args
+    ),
+  );
+
+  # ssh to the box and touch a file for proof of life
+  $self->handle_log([ "about to run ssh: %s", \@ssh_command ]);
+
+  my ($exitcode, $stdout, $stderr) = await $self->dobby->loop->run_process(
+    capture => [ qw( exitcode stdout stderr ) ],
+    command => [ @ssh_command ],
+  );
+
+  $self->handle_log([ "we ran ssh: %s", Process::Status->new($exitcode)->as_struct ]);
+
+  if ($exitcode == 0) {
+    $self->handle_message("In-a-Box ($droplet->{name}) is now set up!");
+    return;
+  }
+
+  my %snippet = (
+    title     => "In-a-Box setup failure ($droplet->{name})",
+    file_name => "In-a-Box-setup-failure-$droplet->{name}.txt",
+    content   => "$stderr\n----(stdout)----\n$stdout",
+  );
+
+  my $url = await $self->handle_snippet(\%snippet);
+
+  if ($url) {
+    $self->handle_message("Something went wrong setting up your box.  Here's more detail: $url");
+  } else {
+    $self->handle_message("Something went wrong setting up your box.");
+  }
+
+  return;
+}
+
+async sub find_and_destroy_droplet ($self, $arg) {
+  my $username = $arg->{username};
+  my $tag      = $arg->{tag};
+  my $force    = $arg->{force};
+
+  my $droplet = await $self->_get_droplet_for($username, $tag);
+
+  unless ($droplet) {
+    $self->handle_error(
+      "That box doesn't exist: " . $self->box_name_for($username, $tag)
+    );
+  }
+
+  await $self->destroy_droplet($droplet, { force => $arg->{force} });
+}
+
+async sub destroy_droplet ($self, $droplet, $arg) {
+  my $can_destroy = $arg->{force} || $droplet->{status} ne 'active';
+
+  unless ($can_destroy) {
+    $self->handle_error(
+      "That box is powered on. Shut it down first, or use force to destroy it anyway."
+    );
+  }
+
+  $self->handle_log([ "Destroying dns entries of: %s", $droplet->{name} ]);
+
+  await $self->dobby->remove_domain_records_for_ip(
+    $self->box_domain,
+    $self->_ip_address_for_droplet($droplet),
+  );
+
+  $self->handle_log([ "Destroying droplet: %s (%s)", $droplet->{id}, $droplet->{name} ]);
+
+  await $self->dobby->destroy_droplet($droplet->{id});
+
+  $self->handle_log([ "Destroyed droplet: %s", $droplet->{id} ]);
+
+  $self->handle_message("Box destroyed: " . $droplet->{name});
+  return;
+}
+
+async sub take_droplet_action ($self, $username, $tag, $action) {
+  my $gerund = $action eq 'on'       ? 'powering on'
+             : $action eq 'off'      ? 'powering off'
+             : $action eq 'shutdown' ? 'shutting down'
+             : die "unknown power action $action!";
+
+  my $past_tense = $action eq 'shutdown' ? 'shut down' : "powered $action";
+
+  my $droplet = await $self->_get_droplet_for($username, $tag);
+
+  unless ($droplet) {
+    $self->handle_error("I can't find a box to do that to!");
+  }
+
+  my $expect_off = $action eq 'on';
+
+  if ( (  $expect_off && $droplet->{status} eq 'active')
+    || (! $expect_off && $droplet->{status} ne 'active')
+  ) {
+    $self->handle_error("That box is already $past_tense!");
+  }
+
+  $self->handle_log([ "$gerund droplet: %s", $droplet->{id} ]);
+
+  $self->handle_message("I've started $gerund that box…");
+
+  my $method = $action eq 'shutdown' ? 'shutdown' : "power_$action";
+
+  eval {
+    await $self->dobby->take_droplet_action($droplet->{id}, $method);
+  };
+
+  if (my $error = $@) {
+    $self->handle_log([
+      "error when taking %s action on droplet: %s",
+      $method,
+      $@,
+    ]);
+
+    $self->handle_error(
+      "Something went wrong while $gerund box, check the DigitalOcean console and maybe try again.",
+    );
+  }
+
+  $self->handle_message("That box has been $past_tense.");
+
+  return;
+}
+
+async sub _get_ssh_key ($self, $spec) {
+  my $dobby = $self->dobby;
+  my $keys = await $dobby->json_get_pages_of("/account/keys", 'ssh_keys');
+
+  my $want_key = $spec->digitalocean_ssh_key_name;
+  my ($ssh_key) = grep {; $_->{name} eq $want_key } @$keys;
+
+  if ($ssh_key) {
+    $self->handle_log([ "Found SSH key: %s (%s)", $ssh_key->@{ qw(id name) } ]);
+    return $ssh_key;
+  }
+
+  $self->handle_log("fminabox SSH key not found?!");
+  $self->handle_error("Hmm, I couldn't find a DO ssh key to use for fminabox!");
+}
+
+
+sub _dns_name_for ($self, $username, $tag = undef) {
+  my $name = join '-', $username, ($tag ? $tag : ());
+  return join '.', $name, 'box';
+}
+
+sub box_name_for ($self, $username, $tag = undef) {
+  return join '.', $self->_dns_name_for($username, $tag), $self->box_domain;
+}
+
+async sub _get_droplet_for ($self, $username, $tag) {
+  my $name = $self->box_name_for($username, $tag);
+
+  my $droplets = await $self->get_droplets_for($username);
+
+  my ($droplet) = grep {; $_->{name} eq $name } @$droplets;
+
+  return $droplet;
+}
+
+async sub get_droplets_for ($self, $username) {
+  my $dobby = $self->dobby;
+  my $tag   = "owner:$username";
+
+  my @droplets = await $dobby->get_droplets_with_tag($tag);
+
+  return \@droplets;
+}
+
+async sub get_snapshot_for_version ($self, $version) {
+  my $dobby = $self->dobby;
+  my $snaps = await $dobby->json_get_pages_of('/snapshots', 'snapshots');
+
+  my ($snapshot) = sort { $b->{created_at} cmp $a->{created_at} }
+                   grep { $_->{name} =~ m/^fminabox-\Q$version\E/ }
+                   @$snaps;
+
+  if ($snapshot) {
+    return $snapshot;
+  }
+
+  $self->handle_error("no snapshot found for fminabox-$version");
+}
+
+sub _ip_address_for_droplet ($self, $droplet) {
+  # we want the public address, not the internal VPC address that we don't use
+  my ($ip_address) =
+    map { $_->{ip_address} }
+    grep { $_->{type} eq 'public'}
+      $droplet->{networks}{v4}->@*;
+  return $ip_address;
+}
+
+sub _format_droplet ($self, $droplet) {
+  return sprintf
+    "name: %s  image: %s  ip: %s  region: %s  status: %s",
+    $droplet->{name},
+    $droplet->{image}{name},
+    $self->_ip_address_for_droplet($droplet),
+    "$droplet->{region}{name} ($droplet->{region}{slug})",
+    $droplet->{status};
+}
+
+sub _validate_setup_args ($self, $args) {
+  return !! (@$args == grep {; /\A[-.a-zA-Z0-9]+\z/ } @$args);
+}
+
+1;

--- a/lib/Synergy/BoxManager.pm
+++ b/lib/Synergy/BoxManager.pm
@@ -65,6 +65,8 @@ package Synergy::BoxManager::ProvisionRequest {
   has image_id    => (is => 'ro', isa => 'Str',     required => 0);
 
   has tag         => (is => 'ro', isa => 'Maybe[Str]');
+
+  has extra_tags  => (is => 'ro', isa => 'ArrayRef[Str]', default => sub { [] });
   has project_id  => (is => 'ro', isa => 'Maybe[Str]');
 
   has is_default_box   => (is => 'ro', isa => 'Bool', default => 0);
@@ -101,8 +103,8 @@ async sub create_droplet ($self, $spec) {
   my $snapshot_id = await $self->_get_snapshot_id($spec);
   my $ssh_key  = await $self->_get_ssh_key($spec);
 
-  # We get this early so that we don't bother creating the Droplet if weren't
-  # not going to be able to authenticate to it.
+  # We get this early so that we don't bother creating the Droplet if we're not
+  # going to be able to authenticate to it.
   my $key_file = $self->_get_my_ssh_key_file($spec);
 
   my %droplet_create_args = (
@@ -111,7 +113,7 @@ async sub create_droplet ($self, $spec) {
     size     => $spec->size,
     image    => $snapshot_id,
     ssh_keys => [ $ssh_key->{id} ],
-    tags     => [ 'fminabox', "owner:" . $spec->username ],
+    tags     => [ "owner:" . $spec->username, $spec->extra_tags->@* ],
   );
 
   $self->handle_log([ "Creating droplet: %s", \%droplet_create_args ]);

--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -13,6 +13,7 @@ use Future::AsyncAwait;
 
 use Dobby::Client;
 use Process::Status;
+use Synergy::BoxManager;
 use Synergy::CommandPost;
 use Synergy::Logger '$Logger';
 use Synergy::Util qw(bool_from_text reformat_help);
@@ -24,18 +25,23 @@ use Time::Duration qw(ago);
 use DateTime::Format::ISO8601;
 use Path::Tiny;
 
-# This SSH key will be used to connect to boxes after they're stood up to run commands.
-has ssh_key_id => (
-  is  => 'ro',
-  isa => 'Str',
-  required => 1,
+has box_manager_config => (
+  is => 'ro',
+  required  => 1,
 );
 
-has digitalocean_ssh_key_name => (
-  is  => 'ro',
-  isa => 'Str',
-  default => 'synergy',
-);
+sub box_manager_for_event ($self, $event) {
+  return Synergy::BoxManager->new({
+    $self->box_manager_config->%*,
+
+    dobby       => $self->dobby,
+
+    error_cb    => sub ($error) { Synergy::X->throw_public($error) },
+    log_cb      => sub ($log)   { $Logger->log($log) },
+    message_cb  => sub ($msg)   { $event->reply($msg) },
+    snippet_cb  => $self->_mk_snippet_cb($event),
+  });
+}
 
 has digitalocean_api_token => (
   is       => 'ro',
@@ -68,10 +74,16 @@ has vpn_config_file => (
   required => 1,
 );
 
-has box_domain => (
-  is       => 'ro',
-  isa      => 'Str',
-  required => 1,
+has ssh_key_id => (
+  is  => 'ro',
+  isa => 'Str',
+  required => 1
+);
+
+has digitalocean_ssh_key_name => (
+  is  => 'ro',
+  isa => 'Str',
+  default => 'synergy',
 );
 
 has box_project_id => (
@@ -105,6 +117,13 @@ has known_box_versions => (
   default => sub ($self) {
     return [ $self->default_box_version ];
   },
+);
+
+# This is not here so we can set it to zero and get rate limited or see bugs in
+# production.  It's here so we can make the tests run fast. -- rjbs, 2024-02-09
+has post_creation_delay => (
+  is => 'ro',
+  default => 5,
 );
 
 my %command_handler = (
@@ -209,7 +228,8 @@ sub _determine_version_and_tag ($self, $event, $switches) {
 }
 
 async sub handle_status ($self, $event, $switches) {
-  my $droplets = await $self->_get_droplets_for($event->from_user);
+  my $boxman   = $self->box_manager_for_event($event);
+  my $droplets = await $boxman->get_droplets_for($event->from_user->username);
 
   if (@$droplets) {
     return await $event->reply(join "\n",
@@ -221,16 +241,12 @@ async sub handle_status ($self, $event, $switches) {
   return await $event->reply("You don't seem to have any boxes.");
 }
 
-# This is not here so we can set it to zero and get rate limited or see bugs in
-# production.  It's here so we can make the tests run fast. -- rjbs, 2024-02-09
-has post_creation_delay => (
-  is => 'ro',
-  default => 5,
-);
-
 async sub handle_image ($self, $event, $switches) {
   my ($version) = $self->_determine_version_and_tag($event, $switches);
-  my $snapshot = await $self->_get_snapshot($version);
+  my $boxman   = $self->box_manager_for_event($event);
+
+  my $snapshot = await $boxman->get_snapshot_for_version($version);
+
   return await $event->reply("Unable to find a snapshot for version $version") unless $snapshot;
 
   my $created_at = DateTime::Format::ISO8601->parse_datetime($snapshot->{created_at})->epoch;
@@ -261,265 +277,48 @@ async sub handle_create ($self, $event, $switches) {
                         : $switches->{nosetup}  ? 0
                         : $self->get_user_preference($user, 'setup-by-default');
 
-  my $maybe_droplet = await $self->_get_droplet_for($user, $tag);
-
-  if ($maybe_droplet) {
-    Synergy::X->throw_public(
-      "This box already exists: " . $self->_format_droplet($maybe_droplet)
-    );
-  }
-
-  my $name = $self->_box_name_for($user, $tag);
   my $region = $switches->{datacentre} // $self->_region_for_user($user);
-  $event->reply("Creating $name in $region, this will take a minute or two.");
 
-  # It would be nice to do these in parallel, but in testing that causes
-  # *super* strange errors deep down in IO::Async if one of the calls fails and
-  # the other does not, so here we'll just admit defeat and do them in
-  # sequence. -- michael, 2020-04-02
-  my $snapshot = await $self->_get_snapshot($version);
-  my %snapshot_regions = map {; $_ => 1 } $snapshot->{regions}->@*;
+  my $spec = Synergy::BoxManager::ProvisionRequest->new({
+    version   => $version,
+    tag       => $tag,
+    size      => $size,
+    username  => $user->username,
+    region    => $region,
+    is_default_box   => $is_default_box,
+    project_id       => $self->box_project_id,
+    run_custom_setup => $should_run_setup,
+    setup_switches   => $switches->{setup},
 
-  unless ($snapshot_regions{$region}) {
-    my $compatible_regions =
-      join ', ',
-      grep { $snapshot_regions{$_} } $self->box_datacentres->@*;
+    ssh_key_id => $self->ssh_key_id,
+    digitalocean_ssh_key_name => $self->digitalocean_ssh_key_name
+  });
 
-    if ($compatible_regions) {
-      return await $event->reply(
-        "I'm unable to create an fminabox in region '$region'.  Available compatible regions are $compatible_regions.  You can use /datacentre switch to specify a compatible one"
-      );
-    }
-
-    return await $event->reply(
-      "I'm unable to create an fminabox in region '$region'.  Unfortunately this snapshot is not available in any of my configured regions"
-    );
-  }
-
-  my $key_file = $self->_get_my_ssh_key_file;
-
-  my $ssh_key  = await $self->_get_ssh_key;
-
-  my $username = $user->username;
-
-  my %droplet_create_args = (
-    name     => $name,
-    region   => $region,
-    size     => $size,
-    image    => $snapshot->{id},
-    ssh_keys => [ $ssh_key->{id} ],
-    tags     => [ 'fminabox', "owner:$username" ],
-  );
-
-  $Logger->log([ "Creating droplet: %s", \%droplet_create_args ]);
-
-  my $droplet = await $self->dobby->create_droplet(\%droplet_create_args);
-
-  unless ($droplet) {
-    Synergy::X->throw_public("There was an error creating the box. Try again.");
-  }
-
-  # We delay this because a completed droplet sometimes does not show up in GET
-  # /droplets immediately, which causes annoying problems.  Waiting 5s is a
-  # silly fix, but seems to work, and it's not like box creation is
-  # lightning-fast anyway. -- michael, 2021-04-16
-  await $self->hub->loop->delay_future(after => $self->post_creation_delay);
-
-  $droplet = await $self->_get_droplet_for($user, $tag);
-
-  if ($droplet) {
-    $Logger->log([ "Created droplet: %s (%s)", $droplet->{id}, $droplet->{name} ]);
-  } else {
-    # We don't fail here, because we want to try to update DNS regardless.
-    $event->error_reply(
-      "Box was created, but now I can't find it! Check the DigitalOcean console and maybe try again."
-    );
-  }
-
-  # Add it to the relevant project. If this fails, then...oh well.
-  # -- ?
-  if ($self->has_project_id) {
-    await $self->dobby->add_droplet_to_project(
-      $droplet->{id},
-      $self->box_project_id
-    );
-  }
-
-  # update the DNS name. we will assume this succeeds; if it fails the box
-  # is still good and there's not really much else we can do.
-  my $ip_address = $self->_ip_address_for_droplet($droplet);
-
-  my @names = (
-    $self->_dns_name_for($event->from_user, $tag),
-    ($is_default_box ? $self->_dns_name_for($event->from_user) : ())
-  );
-
-  for my $name (@names) {
-    $Logger->log("updating DNS names for $name");
-
-    await $self->dobby->point_domain_record_at_ip(
-      $self->box_domain,
-      $name,
-      $ip_address,
-    );
-  }
-
-  await $event->reply(
-    "Box created, will now run setup. Your box is: "
-    . $self->_format_droplet($droplet)
-  );
-
-  return await $self->_setup_droplet(
-    $event,
-    $droplet,
-    $key_file,
-    $should_run_setup,
-    $switches->{setup} // [], # might be undef if setting up by default
-  );
-
+  my $boxman  = $self->box_manager_for_event($event);
+  my $droplet = await $boxman->create_droplet($spec);
+  return;
 }
 
-sub _get_my_ssh_key_file ($self) {
-  my $key_file = $self->ssh_key_id
-               ? path($self->ssh_key_id)->absolute("$ENV{HOME}/.ssh/")
-               : undef;
-
-  unless ($key_file && -r $key_file) {
-    $Logger->log(["Cannot read SSH key for inabox setup (from %s)", $self->ssh_key_id]);
-    Synergy::X->throw_public(
-      "No SSH credentials for running box setup. This is a problem - aborting."
-    );
-  }
-
-  return $key_file;
-}
-
-sub _validate_setup_args ($self, $args) {
-  return !! (@$args == grep {; /\A[-.a-zA-Z0-9]+\z/ } @$args);
-}
-
-async sub _setup_droplet ($self, $event, $droplet, $key_file, $custom_setup, $args = []) {
-  my $ip_address = $self->_ip_address_for_droplet($droplet);
-
-  unless ($self->_validate_setup_args($args)) {
-    $event->reply("Your /setup arguments don't meet my strict and undocumented requirements, sorry.  I'll act like you provided none.");
-    $args = [];
-  }
-
-  my $success;
-  my $max_tries = 20;
-  TRY: for my $try (1..$max_tries) {
-    my $socket;
-    eval {
-      $socket = await $self->hub->loop->connect(addr => {
-        family   => 'inet',
-        socktype => 'stream',
-        port     => 22,
-        ip       => $ip_address,
-      });
-    };
-
-    if ($socket) {
-      # We didn't need the connection, just to know it worked!
-      undef $socket;
-
-      $Logger->log([
-        "ssh on %s is up, will now move on to running setup",
-        $ip_address,
-      ]);
-
-      $success = 1;
-
-      last TRY;
-    }
-
-    my $error = $@;
-    if ($error !~ /Connection refused/) {
-      $Logger->log([
-        "weird error connecting to %s:22: %s",
-        $ip_address,
-        $error,
-      ]);
-    }
-
-    $Logger->log([
-      "ssh on %s is not up, maybe wait and try again; %s tries remain",
-      $ip_address,
-      $max_tries - $try,
-    ]);
-
-    await $self->hub->loop->delay_future(after => 1);
-  }
-
-  unless ($success) {
-    return await $event->reply("I couldn't connect to your box to set it up.");
-  }
-
-  # ssh to the box and touch a file for proof of life
-  $Logger->log("about to run ssh!");
-
-  my @setup_args = $custom_setup ? () : ('--no-custom');
-
-  my ($exitcode, $stdout, $stderr) = await $self->hub->loop->run_process(
-    capture => [ qw( exitcode stdout stderr ) ],
-    command => [
-      "ssh",
-        '-A',
-        '-i', "$key_file",
-        '-l', 'root',
-        '-o', 'UserKnownHostsFile=/dev/null',
-        '-o', 'StrictHostKeyChecking=no',
-
-      $ip_address,
-      (
-        qw( fmdev mysetup ),
-        '--user', $event->from_user->username,
-        @setup_args,
-        '--',
-        @$args
-      ),
-    ],
-  );
-
-  $Logger->log([ "we ran ssh: %s", Process::Status->new($exitcode)->as_struct ]);
-
-  if ($exitcode == 0) {
-    return await $event->reply("In-a-Box ($droplet->{name}) is now set up!");
-  }
-
-  my $message = "Something went wrong setting up your box.";
-
-  # If there's a pastebin/snippet capable reactor, use that
-  # If there isn't, and the current channel is slack, use a slack snippet
-  # else, discard stdout/stderr and return only an error message
+sub _mk_snippet_cb ($self, $event) {
+  # If there's a pastebin/snippet capable reactor, use that.
+  # Otherwise, discard stdout/stderr and just provide an error message.
   if ($self->snippet_reactor_name && $self->hub->reactor_named($self->snippet_reactor_name)) {
-    my %payload;
-    $payload{title} = "In-a-Box setup failure ($droplet->{name})";
-    $payload{file_name} = "In-a-Box-setup-failure-$droplet->{name}.txt";
-    $payload{content} = "$stderr\n----(stdout)----\n$stdout";
-
-    my $snippet_url = await $self->hub->reactor_named('gitlab')
-      ->post_gitlab_snippet(\%payload);
-    $message .= " Here's a link to the output: $snippet_url";
-    return await $event->reply($message);
+    my $reactor = $self->hub->reactor_named($self->snippet_reactor_name);
+    return async sub ($snippet) {
+      return await $reactor->post_gitlab_snippet($snippet);
+    };
   }
 
-  if ($event->from_channel->isa('Synergy::Channel::Slack')) {
-    $message .= " Here's the output from setup:";
-
-    my $content = "$stderr\n----(stdout)----\n$stdout";
-    await $event->from_channel->slack->send_file($event->conversation_address, 'setup.log', $content);
-  } else {
-    $Logger->log("we ran ssh, but not via Slack, so stdout/stderr discarded");
+  return async sub ($arg) {
+    return;
   }
-
-  return await $event->reply($message);
 }
 
 async sub handle_destroy ($self, $event, $switches) {
   my ($version, $tag) = $self->_determine_version_and_tag($event, $switches);
 
   my $force = delete $switches->{force};
+  $force //= $self->get_user_preference($event->from_user, 'destroy-always-force');
 
   if (%$switches) {
     my $unrecognized = "";
@@ -535,125 +334,40 @@ async sub handle_destroy ($self, $event, $switches) {
     );
   }
 
-  my $droplet = await $self->_get_droplet_for($event->from_user, $tag);
+  my $username = $event->from_user->username;
+  my $boxman  = $self->box_manager_for_event($event);
 
-  unless ($droplet) {
-    Synergy::X->throw_public(
-      "That box doesn't exist: " . $self->_box_name_for($event->from_user, $tag)
-    );
-  }
-
-  my $can_destroy
-    = $self->get_user_preference($event->from_user, 'destroy-always-force') ? 1
-    : $force                                                                ? 1
-    : $droplet->{status} eq 'active'                                        ? 0
-    :                                                                         1;
-
-  unless ($can_destroy) {
-    Synergy::X->throw_public(
-      "That box is powered on. Shut it down first, or use /force to destroy it anyway."
-    );
-  }
-
-  $Logger->log([ "Destroying dns entries of: %s", $droplet->{name} ]);
-
-  await $self->dobby->remove_domain_records_for_ip(
-    $self->box_domain,
-    $self->_ip_address_for_droplet($droplet),
-  );
-
-  $Logger->log([ "Destroying droplet: %s (%s)", $droplet->{id}, $droplet->{name} ]);
-
-  await $self->dobby->destroy_droplet($droplet->{id});
-
-  $Logger->log([ "Destroyed droplet: %s", $droplet->{id} ]);
-  return await $event->reply("Box destroyed: " . $self->_box_name_for($event->from_user, $tag));
-}
-
-async sub _handle_power ($self, $event, $action, $tag = undef) {
-  my $remove_reactji = sub ($alt_text) {
-    $event->private_reply($alt_text, {
-      slack_reaction => {
-        event => $event,
-        reaction => '-vertical_traffic_light',
-      },
-    });
-  };
-
-  my $gerund = $action eq 'on'       ? 'powering on'
-             : $action eq 'off'      ? 'powering off'
-             : $action eq 'shutdown' ? 'shutting down'
-             : die "unknown power action $action!";
-
-  my $past_tense = $action eq 'shutdown' ? 'shut down' : "powered $action";
-
-  my $droplet = await $self->_get_droplet_for($event->from_user, $tag);
-
-  unless ($droplet) {
-    Synergy::X->throw_public("I can't find a box to do that to!");
-  }
-
-  my $expect_off = $action eq 'on';
-
-  if ( (  $expect_off && $droplet->{status} eq 'active')
-    || (! $expect_off && $droplet->{status} ne 'active')
-  ) {
-    Synergy::X->throw_public("That box is already $past_tense!");
-  }
-
-  $Logger->log([ "$gerund droplet: %s", $droplet->{id} ]);
-
-  $event->reply(
-    "I'm pulling the levers, it'll be just a moment",
-    {
-      slack_reaction => {
-        event => $event,
-        reaction => 'vertical_traffic_light',
-      }
-    },
-  );
-
-  my $method = $action eq 'shutdown' ? 'shutdown' : "power_$action";
-
-  eval {
-    await $self->dobby->take_droplet_action($droplet->{id}, $method);
-  };
-
-  if (my $error = $@) {
-    $Logger->log([
-      "error when taking %s action on droplet: %s",
-      $method,
-      $@,
-    ]);
-
-    $remove_reactji->('Error!');
-    Synergy::X->throw_public(
-      "Something went wrong while $gerund box, check the DigitalOcean console and maybe try again.",
-    );
-  }
-
-  $remove_reactji->("$past_tense!");
-  $event->reply("That box has been $past_tense.");
+  await $boxman->find_and_destroy_droplet({
+    username => $username,
+    tag      => $tag,
+    force    => $force,
+  });
 
   return;
 }
 
-sub handle_shutdown ($self, $event, $switches) {
-  my ($version, $tag) = $self->_determine_version_and_tag($event, $switches);
+async sub handle_shutdown ($self, $event, $switches) {
+  my (undef, $tag) = $self->_determine_version_and_tag($event, $switches);
 
-  return $self->_handle_power($event, 'shutdown', $tag);
+  my $username = $event->from_user->username;
+  my $boxman   = $self->box_manager_for_event($event);
+  await $boxman->take_droplet_action($username, $tag, 'shutdown');
 }
 
-sub handle_poweroff ($self, $event, $switches) {
-  my ($version, $tag) = $self->_determine_version_and_tag($event, $switches);
+async sub handle_poweroff ($self, $event, $switches) {
+  my (undef, $tag) = $self->_determine_version_and_tag($event, $switches);
 
-  $self->_handle_power($event, 'off', $tag);
+  my $username = $event->from_user->username;
+  my $boxman   = $self->box_manager_for_event($event);
+  await $boxman->take_droplet_action($username, $tag, 'off');
 }
 
-sub handle_poweron ($self, $event, $switches) {
-  my ($version, $tag) = $self->_determine_version_and_tag($event, $switches);
+async sub handle_poweron ($self, $event, $switches) {
+  my (undef, $tag) = $self->_determine_version_and_tag($event, $switches);
 
-  return $self->_handle_power($event, 'on', $tag);
+  my $username = $event->from_user->username;
+  my $boxman   = $self->box_manager_for_event($event);
+  await $boxman->take_droplet_action($username, $tag, 'on');
 }
 
 async sub handle_vpn ($self, $event, $switches) {
@@ -665,33 +379,17 @@ async sub handle_vpn ($self, $event, $switches) {
     DELIMITERS => [ '{{', '}}' ],
   );
 
+  my $boxman = $self->box_manager_for_event($event);
   my $config = $template->fill_in(HASH => {
-    droplet_host => $self->_box_name_for($event->from_user, ($is_default_box ? () : $tag)),
+    droplet_host => $boxman->box_name_for(
+      $event->from_user->username,
+      ($is_default_box ? () : $tag)
+    ),
   });
 
   await $event->from_channel->send_file_to_user($event->from_user, 'fminabox.conf', $config);
 
   await $event->reply("I sent you a VPN config in a direct message. Download it and import it into your OpenVPN client.");
-}
-
-async sub _get_droplet_for ($self, $user, $tag = undef) {
-  my $name = $self->_box_name_for($user, $tag);
-
-  my $droplets = await $self->_get_droplets_for($user);
-
-  my ($droplet) = grep {; $_->{name} eq $name } @$droplets;
-
-  return $droplet;
-}
-
-async sub _get_droplets_for ($self, $user) {
-  my $dobby = $self->dobby;
-  my $username = $user->username;
-  my $tag   = "owner:$username";
-
-  my @droplets = await $dobby->get_droplets_with_tag($tag);
-
-  return \@droplets;
 }
 
 sub _ip_address_for_droplet ($self, $droplet) {
@@ -711,45 +409,6 @@ sub _format_droplet ($self, $droplet) {
     $self->_ip_address_for_droplet($droplet),
     "$droplet->{region}{name} ($droplet->{region}{slug})",
     $droplet->{status};
-}
-
-async sub _get_snapshot ($self, $version) {
-  my $dobby = $self->dobby;
-  my $snaps = await $dobby->json_get_pages_of('/snapshots', 'snapshots');
-
-  my ($snapshot) = sort { $b->{created_at} cmp $a->{created_at} }
-                   grep { $_->{name} =~ m/^fminabox-\Q$version\E/ }
-                   @$snaps;
-
-  if ($snapshot) {
-    return $snapshot;
-  }
-
-  Synergy::X->throw_public("no snapshot found for fminabox-$version");
-}
-
-async sub _get_ssh_key ($self) {
-  my $dobby = $self->dobby;
-  my $keys = await $dobby->json_get_pages_of("/account/keys", 'ssh_keys');
-
-  my ($ssh_key) = grep {; $_->{name} eq $self->digitalocean_ssh_key_name } @$keys;
-
-  if ($ssh_key) {
-    $Logger->log([ "Found SSH key: %s (%s)", $ssh_key->@{ qw(id name) } ]);
-    return $ssh_key;
-  }
-
-  $Logger->log([ "fminabox SSH key not found?!" ]);
-  Synergy::X->throw_public("Hmm, I couldn't find a DO ssh key to use for fminabox!");
-}
-
-sub _dns_name_for ($self, $user, $tag = undef) {
-  my $name = join '-', $user->username, ($tag ? $tag : ());
-  return join '.', $name, 'box';
-}
-
-sub _box_name_for ($self, $user, $tag = undef) {
-  return join '.', $self->_dns_name_for($user, $tag), $self->box_domain;
 }
 
 sub _region_for_user ($self, $user) {

--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -119,13 +119,6 @@ has known_box_versions => (
   },
 );
 
-# This is not here so we can set it to zero and get rate limited or see bugs in
-# production.  It's here so we can make the tests run fast. -- rjbs, 2024-02-09
-has post_creation_delay => (
-  is => 'ro',
-  default => 5,
-);
-
 my %command_handler = (
   info     => \&handle_status,
   status   => \&handle_status,

--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -289,6 +289,7 @@ async sub handle_create ($self, $event, $switches) {
     project_id       => $self->box_project_id,
     run_custom_setup => $should_run_setup,
     setup_switches   => $switches->{setup},
+    extra_tags       => [ 'fminabox' ],
 
     ssh_key_id => $self->ssh_key_id,
     digitalocean_ssh_key_name => $self->digitalocean_ssh_key_name

--- a/t/01-compile.t
+++ b/t/01-compile.t
@@ -11,6 +11,7 @@ my @files = `find lib -type f -name '*.pm'`;
 chomp @files;
 
 my %only_if = (
+  'Synergy::BoxManager'                   => [ 'Dobby::Client' ],
   'Synergy::Reactor::InABox'              => [ 'Dobby::Client' ],
   'Synergy::Reactor::Linear'              => [ 'Linear::Client' ],
   'Synergy::Reactor::LinearNotification'  => [ 'Linear::Client' ],


### PR DESCRIPTION
Synergy is great and all, but sometimes it's nice to manage boxes from outside of chatops.  Making that possible was the real reason behind ever writing Dobby, and this commit realizes it.  This abstracts box management (create, destroy, setup, power events) from the InABox reactor.

The BoxManager needs to be given callbacks for chatops things like sending replies.  In a console environment, these can be replaced with something like "print".