### PR TITLE
ci/before-build: run things before build in CI

### DIFF
--- a/ci/before-build
+++ b/ci/before-build
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+cd /tmp
+git clone https://github.com/fastmail/Dobby
+cd Dobby
+perl Makefile.PL
+make
+make install


### PR DESCRIPTION
We recently had some breakage on Synergy's inabox tests because the CI didn't run them, because it was set to skip the Dobby tests if Dobby wasn't installed.  This is foolish.  CI should actually test it all.

Because Dobby is not on the CPAN, we need a way to install it some other way.  To accomplish this, I've extended the dzil-actions definition of tarball testing to allow them to run a `./ci/before-build` program before the dist is built.

This PR adds such a program for Synergy, adding Dobby.