### PR TITLE
Reactor/InABox.pm: Add 'label' alias for 'tag' switch

### DIFF
--- a/lib/Synergy/Reactor/InABox.pm
+++ b/lib/Synergy/Reactor/InABox.pm
@@ -179,6 +179,7 @@ command box => {
     datacenter  => 'datacentre',
     region      => 'datacentre',
     tag         => 'ident',
+    label       => 'ident',
   });
 
   my %switches = map { my ($k, @rest) = @$_; $k => \@rest } @$switches;


### PR DESCRIPTION
I like 'label'.