### PR TITLE
Reactor/Linear: Don't expand more than 3 mentions in one message

### DIFF
--- a/lib/Synergy/Reactor/Linear.pm
+++ b/lib/Synergy/Reactor/Linear.pm
@@ -202,6 +202,9 @@ listener issue_mention => async sub ($self, $event) {
 
   return unless @matches;
 
+  # if there's more than 3 issues to unroll that's probably spam
+  return unless (@matches < 4);
+
   # Do not warn about missing tokens in public about in-passing mentions
   my $user = $event->from_user;
   if ( $event->is_public


### PR DESCRIPTION
This creates a lot of spam, so let's not.

It would maybe be more elegant to make a "would you like to expand these" question box. I'll make that a Fryday task.